### PR TITLE
Use a dynamic wp-load.php path for require_once()

### DIFF
--- a/core/lib/upload/um-file-upload.php
+++ b/core/lib/upload/um-file-upload.php
@@ -1,6 +1,15 @@
 <?php
 
-require_once("../../../../../../wp-load.php");
+$i = 0;
+$dirname = dirname( __FILE__ );
+
+do {
+	$dirname = dirname( $dirname );
+	$wp_load = "{$dirname}/wp-load.php";
+}
+while( ++$i < 10 && !file_exists( $wp_load ) );
+
+require_once( $wp_load );
 global $ultimatemember;
 
 $id = $_POST['key'];

--- a/core/lib/upload/um-image-upload.php
+++ b/core/lib/upload/um-image-upload.php
@@ -1,6 +1,15 @@
 <?php
 
-require_once("../../../../../../wp-load.php");
+$i = 0;
+$dirname = dirname( __FILE__ );
+
+do {
+	$dirname = dirname( $dirname );
+	$wp_load = "{$dirname}/wp-load.php";
+}
+while( ++$i < 10 && !file_exists( $wp_load ) );
+
+require_once( $wp_load );
 global $ultimatemember;
 
 $id = $_POST['key'];


### PR DESCRIPTION
Both the plugin directory and the wp-content directory can be moved around in the installation. The location of `wp-load.php` should not be assumed.