### PR TITLE
Fixes img error on Edit Profile page (see error in console)

### DIFF
--- a/core/lib/upload/um-file-upload.php
+++ b/core/lib/upload/um-file-upload.php
@@ -1,6 +1,17 @@
 <?php
 
-require_once("../../../../../../wp-load.php");
+$i = 0;
+
+$dirname = dirname( $_SERVER['SCRIPT_FILENAME'] );
+
+do {
+	$dirname = dirname( $dirname );
+	$wp_load = realpath( "{$dirname}/wp-load.php" );
+}
+while( ++$i < 10 && !file_exists( $wp_load ) );
+
+require_once( $wp_load );
+
 global $ultimatemember;
 
 $id = $_POST['key'];

--- a/core/lib/upload/um-image-upload.php
+++ b/core/lib/upload/um-image-upload.php
@@ -1,6 +1,17 @@
 <?php
 
-require_once("../../../../../../wp-load.php");
+$i = 0;
+
+$dirname = dirname( $_SERVER['SCRIPT_FILENAME'] );
+
+do {
+	$dirname = dirname( $dirname );
+	$wp_load = realpath( "{$dirname}/wp-load.php" );
+}
+while( ++$i < 10 && !file_exists( $wp_load ) );
+
+require_once( $wp_load );
+
 global $ultimatemember;
 
 $id = $_POST['key'];

--- a/core/um-actions-account.php
+++ b/core/um-actions-account.php
@@ -28,7 +28,7 @@
 		$ultimatemember->user->update_profile( $changes );
 
 		// delete account
-		if ( $_POST['single_user_password'] && isset($_POST['um_account_submit']) && $_POST['um_account_submit'] == __('Delete Account','ultimatemember') ) {
+		if ( isset($_POST['single_user_password']) && isset($_POST['um_account_submit']) && $_POST['um_account_submit'] == __('Delete Account','ultimatemember') ) {
 			if ( current_user_can('delete_users') || um_user('can_delete_profile') ) {
 				if ( !um_user('super_admin') ) {
 					$ultimatemember->user->delete();

--- a/core/um-fields.php
+++ b/core/um-fields.php
@@ -1244,17 +1244,16 @@ class UM_Fields {
 					
 					if ( $this->field_value( $key, $default, $data ) ) {
 					
-						$uri = um_user_uploads_uri() . $this->field_value( $key, $default, $data );
+						$img = $this->field_value( $key, $default, $data );
 						
 						if ( isset( $ultimatemember->form->errors ) && !empty( $ultimatemember->form->errors ) ) {
 							if ( isset( $this->set_mode ) && $this->set_mode == 'register' ) {
-								$uri = $this->field_value( $key, $default, $data );
+								$img = $this->field_value( $key, $default, $data );
 							}
 						}
 						
 						$output .= '<div class="um-single-image-preview show '. $crop_class .'" data-crop="'.$crop_data.'" data-key="'.$key.'">
-								<a href="#" class="cancel"><i class="um-icon-close"></i></a>
-								<img src="' . $uri . '" alt="" />
+								<a href="#" class="cancel"><i class="um-icon-close"></i></a>' . $img . '
 							</div><a href="#" data-modal="um_upload_single" data-modal-size="'.$modal_size.'" data-modal-copy="1" class="um-button um-btn-auto-width">'. __('Change photo') . '</a>';
 						
 					} else {


### PR DESCRIPTION
If `$type` is an image, `$this->field_value( $key )` returns a html `<img>` element, not an URL (it calls the `um_user()` method for `cover_photo` or `profile_photo` keys).

This pull request fixes the following html output on the Edit Profile page:
```<img src="http://wordpress.dev/wp-content/uploads/ultimatemember/1/<img src="http://wordpress.dev/wp-content/uploads/ultimatemember/1/cover_photo.jpg?1430436356" alt="" />" alt="" />```