### PR TITLE
Make sure the hash parameter is a string

### DIFF
--- a/core/um-permalinks.php
+++ b/core/um-permalinks.php
@@ -104,7 +104,7 @@ class UM_Permalinks {
 	function activate_account_via_email_link(){
 		global $ultimatemember;
 
-		if ( isset($_REQUEST['act']) && $_REQUEST['act'] == 'activate_via_email' && isset($_REQUEST['hash']) && strlen($_REQUEST['hash']) == 40 &&
+		if ( isset($_REQUEST['act']) && $_REQUEST['act'] == 'activate_via_email' && isset($_REQUEST['hash']) && is_string($_REQUEST['hash']) && strlen($_REQUEST['hash']) == 40 &&
 			isset($_REQUEST['user_id']) && is_numeric($_REQUEST['user_id']) ) { // valid token
 
 				$user_id = absint( $_REQUEST['user_id'] );


### PR DESCRIPTION
This prevents an error (leaking path information on poorly configured servers) if a user supplies an array as `hash` parameter.

```
test.org/?act=activate_via_email&hash[]=hash&user_id=1
```

```
Warning: strlen() expects parameter 1 to be string, array given in /var/www/wp-content/plugins/ultimate-member/core/um-permalinks.php on line 75
```