### PR TITLE
Escape display name in title attributes

### DIFF
--- a/templates/members-grid.php
+++ b/templates/members-grid.php
@@ -19,7 +19,7 @@
 		?>
 
 		<div class="um-member-cover" data-ratio="<?php echo um_get_option('profile_cover_ratio'); ?>">
-			<div class="um-member-cover-e"><a href="<?php echo um_user_profile_url(); ?>" title="<?php echo um_user('display_name'); ?>"><?php echo um_user('cover_photo', $cover_size); ?></a></div>
+			<div class="um-member-cover-e"><a href="<?php echo um_user_profile_url(); ?>" title="<?php echo esc_attr(um_user('display_name')); ?>"><?php echo um_user('cover_photo', $cover_size); ?></a></div>
 		</div>
 
 		<?php } ?>
@@ -28,13 +28,13 @@
 			$default_size = str_replace( 'px', '', um_get_option('profile_photosize') );
 			$corner = um_get_option('profile_photocorner');
 		?>
-		<div class="um-member-photo radius-<?php echo $corner; ?>"><a href="<?php echo um_user_profile_url(); ?>" title="<?php echo um_user('display_name'); ?>"><?php echo get_avatar( um_user('ID'), $default_size ); ?></a></div>
+		<div class="um-member-photo radius-<?php echo $corner; ?>"><a href="<?php echo um_user_profile_url(); ?>" title="<?php echo esc_attr(um_user('display_name')); ?>"><?php echo get_avatar( um_user('ID'), $default_size ); ?></a></div>
 		<?php } ?>
 					
 					<div class="um-member-card <?php if (!$profile_photo) { echo 'no-photo'; } ?>">
 						
 						<?php if ( $show_name ) { ?>
-						<div class="um-member-name"><a href="<?php echo um_user_profile_url(); ?>" title="<?php echo um_user('display_name'); ?>"><?php echo um_user('display_name', 'html'); ?></a></div>
+						<div class="um-member-name"><a href="<?php echo um_user_profile_url(); ?>" title="<?php echo esc_attr(um_user('display_name')); ?>"><?php echo um_user('display_name', 'html'); ?></a></div>
 						<?php } ?>
 						
 						<?php do_action('um_members_just_after_name', um_user('ID'), $args); ?>


### PR DESCRIPTION
This fixes a persistent Cross-Site Scripting vulnerability in the Member Directory. Malicious users could update their first and/or last name in their settings to include Javascript. This Javascript would be executed on the Member Directory page because the user's display is used in a `title` attribute without escaping double quotes (`"`). 

How to reproduce:
1. As a regular user, set your first name to `name" onmouseover=alert(document.cookie)`.
2. Navigate to the member directory (as a guest or any user).
3. Mouse-over the member photo of the user with the Javascript payload. 
4. An alert box will now pop up.

This issue is fixed by using the Wordpress function `esc_attr`. Documentation is available [here](http://codex.wordpress.org/Function_Reference/esc_attr).

----------------------

![screenshot 2016-01-27 10 23 07](https://cloud.githubusercontent.com/assets/1312973/12609410/c95aaa94-c4e1-11e5-83b1-cb5f3affa610.png)