### PR TITLE
Move the check for um_flush_stop to the flush_rewrite_rules function …

### DIFF
--- a/core/um-rewrite.php
+++ b/core/um-rewrite.php
@@ -32,7 +32,7 @@ class UM_Rewrite {
 
 		global $ultimatemember;
 
-		if ( isset( $ultimatemember->permalinks->core['user'] ) && !um_get_option('um_flush_stop') ) {
+		if ( isset( $ultimatemember->permalinks->core['user'] ) ) {
 
 			$user_page_id = $ultimatemember->permalinks->core['user'];
 			$account_page_id = $ultimatemember->permalinks->core['account'];
@@ -84,8 +84,8 @@ class UM_Rewrite {
 									'top'
 				);
 
-
-				flush_rewrite_rules( true );
+				if( !apply_filters('up_rewrite_flush_rewrite_rules', um_get_option('um_flush_stop') ) )
+					flush_rewrite_rules( true );
 
 			}
 


### PR DESCRIPTION
…to avoid add_rewrite_rule issues if other plugins flush_rewrite_rules.

We need to make sure the add_rewrite_rule is running each time otherwise the rewrite roles get lost if other plugins flush_rewrite_rules.

Now the um_flush_stop check is moved to the add_rewrite_rule function to make sure add_rewrite_rule is fired.
If the option "Stop rewriting rules on every load" is set to "on" and a plugin flush_rewrite_rules your add_rewrite_rule will get recognised.

I also added a filer 'up_rewrite_flush_rewrite_rules' to allow plugins to stop rewriting without manipulating the option array.

I hope this makes sense for you and help you. My english is not the best let me know if I got something wrong here or you have any question left. I like to help.