### PR TITLE
Cleanup wp_options table upon user deletion in Wordpress

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ultimate Member is a powerful and flexible WordPress plugin that makes it a bree
 
 | Latest Version |Requires at least|Stable Tag|
 | :------------: |:------------:|:------------:|
-| 1.3.70 | WordPress 4.5 or higher| 1.3.70 |
+| 1.3.71 | WordPress 4.5 or higher| 1.3.71 |
 
 
 ##Features of the plugin include:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ultimate Member is a powerful and flexible WordPress plugin that makes it a bree
 
 | Latest Version |Requires at least|Stable Tag|
 | :------------: |:------------:|:------------:|
-| 1.3.69 | WordPress 4.5 or higher| 1.3.69 |
+| 1.3.70 | WordPress 4.5 or higher| 1.3.70 |
 
 
 ##Features of the plugin include:
@@ -48,7 +48,7 @@ GNU Version 2 or Any Later Version
 
 Releases
 ====================
-[Latest Release: Ultimate Member pre-v1.3.69.25](https://github.com/ultimatemember/ultimatemember/releases).
+[Latest Release: Ultimate Member pre-v1.3.70.1](https://github.com/ultimatemember/ultimatemember/releases).
 
 Changelog
 ====================

--- a/core/um-actions-password.php
+++ b/core/um-actions-password.php
@@ -158,10 +158,12 @@
 		if ( $form_timestamp == '' && um_get_option('enable_timebot') == 1 )
 			wp_die( __('Hello, spam bot!') );
 
-		if ( $live_timestamp - $form_timestamp < 3 && um_get_option('enable_timebot') == 1 )
+		if ( $live_timestamp - $form_timestamp < 3 && um_get_option('enable_timebot') == 1 ){
 			wp_die( __('Whoa, slow down! You\'re seeing this message because you tried to submit a form too fast and we think you might be a spam bot. If you are a real human being please wait a few seconds before submitting the form. Thanks!') );
+		}
+		
 
-		if ( isset( $args['user_password'] ) && ! empty( $args['user_password'] ) ) {
+		if ( isset( $args['user_password'] ) && empty( $args['user_password'] ) ) {
 			$ultimatemember->form->add_error('user_password', __('You must enter a new password','ultimatemember') );
 		}
 
@@ -181,7 +183,7 @@
 
 		}
 
-		if ( isset( $args['confirm_user_password'] ) && ! empty( $args['confirm_user_password'] ) ) {
+		if ( isset( $args['confirm_user_password'] ) && empty( $args['confirm_user_password'] ) ) {
 			$ultimatemember->form->add_error('confirm_user_password', __('You must confirm your new password','ultimatemember') );
 		}
 

--- a/core/um-fields.php
+++ b/core/um-fields.php
@@ -2255,8 +2255,12 @@ class UM_Fields {
 						if ( isset( $data['label'] ) ) {
 							$output .= $this->field_label($label, $key, $data);
 						}
+						
+						$res = $this->field_value( $key, $default, $data );
 
-						$res = stripslashes( $this->field_value( $key, $default, $data ) );
+						if( ! empty( $res ) ){
+							$res = stripslashes( $res );
+						}
 
 						$res = apply_filters("um_view_field_value_{$type}", $res, $data );
 

--- a/core/um-form.php
+++ b/core/um-form.php
@@ -124,7 +124,7 @@ class UM_Form {
                     	$role = current( $_POST['role'] );
                     }
 
-					if ( isset( $custom_field_roles ) && ! in_array( $role , $custom_field_roles ) ) {
+					if ( isset( $custom_field_roles ) && is_array(  $custom_field_roles ) && ! in_array( $role , $custom_field_roles ) ) {
 						wp_die( __( 'This is not possible for security reasons.','ultimatemember') );
 					} 
 

--- a/core/um-form.php
+++ b/core/um-form.php
@@ -136,7 +136,7 @@ class UM_Form {
 					$this->post_form['role'] = $role;
 					$this->post_form['submitted']['role'] = $role;
 				}
-                
+				
                
 				if ( isset( $_POST[ $ultimatemember->honeypot ] ) && $_POST[ $ultimatemember->honeypot ] != '' ){
 					wp_die('Hello, spam bot!');
@@ -227,19 +227,19 @@ class UM_Form {
 	function assigned_role( $post_id ){
 
 		$mode = $this->form_type( $post_id );
-		$use_globals = get_post_meta( $post_id, "_um_{mode}_use_globals", true);
+		$use_globals = get_post_meta( $post_id, "_um_{$mode}_use_globals", true);
        
         $global_role = um_get_option('default_role'); // Form Global settings
 
 		if( $use_globals == 0 ){ // Non-Global settings
-			$role = get_post_meta( $post_id, "_um_{mode}_role", true );
+			$role = get_post_meta( $post_id, "_um_{$mode}_role", true );
 		}
 
-		if( ! $role || $role == 0 ){ // custom role is default, return default role's slug
+		if( empty( $role ) ){ // custom role is default, return default role's slug
 			$role = $global_role;
 		}
-
-		return $role;
+        
+    	return $role;
 	
 	}
 

--- a/core/um-members.php
+++ b/core/um-members.php
@@ -155,7 +155,7 @@ class UM_Members {
 
 		$query_args['number'] = $profiles_per_page;
 		
-		$members_page = isset($_REQUEST['members_page']) ? $_REQUEST['members_page'] : 1;
+		$members_page = isset( $_REQUEST['members_page'] ) ? $_REQUEST['members_page'] : 1;
 		
 		$query_args['paged'] = $members_page;
 		
@@ -165,7 +165,7 @@ class UM_Members {
 
 		$array['total_users'] = (isset( $max_users ) && $max_users && $max_users <= $users->total_users ) ? $max_users : $users->total_users;
 
-		$array['page'] = $members_page;
+		$array['page'] = ! isset( $_REQUEST['members_page'] ) ? $args['page'] : $members_page;
 
 		$array['total_pages'] = ceil( $array['total_users'] / $profiles_per_page );
 

--- a/core/um-members.php
+++ b/core/um-members.php
@@ -165,7 +165,7 @@ class UM_Members {
 
 		$array['total_users'] = (isset( $max_users ) && $max_users && $max_users <= $users->total_users ) ? $max_users : $users->total_users;
 
-		$array['page'] = ! isset( $_REQUEST['members_page'] ) ? $args['page'] : $members_page;
+		$array['page'] = ! isset( $_REQUEST['members_page'] ) && isset( $args['page'] ) ? $args['page'] : $members_page;
 
 		$array['total_pages'] = ceil( $array['total_users'] / $profiles_per_page );
 

--- a/core/um-password.php
+++ b/core/um-password.php
@@ -29,7 +29,9 @@ class UM_Password {
 				
 				um_fetch_user( $user_id );
 				
-				if ( $_REQUEST['hash'] != um_user('reset_pass_hash') ) wp_die( __('This is not a valid hash, or it has expired.','ultimatemember') );
+				if ( $_REQUEST['hash'] != um_user('reset_pass_hash') ){
+					wp_die( __('This is not a valid hash, or it has expired.','ultimatemember') );
+				}
 
 				$ultimatemember->user->profile['reset_pass_hash_token'] = current_time( 'timestamp' );
 				$ultimatemember->user->update_usermeta_info('reset_pass_hash_token');
@@ -50,6 +52,10 @@ class UM_Password {
 		
 		if ( !um_user('reset_pass_hash') ) return false;
 		
+		$user_id = um_user('ID');
+		
+		delete_option( "um_cache_userdata_{$user_id}" );
+				
 		$url =  add_query_arg( 'act', 'reset_password', um_get_core_page('password-reset') );
 		$url =  add_query_arg( 'hash', esc_attr( um_user('reset_pass_hash') ), $url );
 		$url =  add_query_arg( 'user_id', esc_attr( um_user('ID') ), $url );

--- a/core/um-user.php
+++ b/core/um-user.php
@@ -49,7 +49,7 @@ class UM_User {
 		add_action( 'edit_user_profile',        array( $this, 'community_role_edit' ) );
 		add_action( 'personal_options_update',  array( $this, 'community_role_save' ) );
 		add_action( 'edit_user_profile_update', array( $this, 'community_role_save' ) );
-
+        add_action( 'delete_user', array($this,'um_delete_user_hook') );
 	}
 
 	/**
@@ -1080,4 +1080,13 @@ class UM_User {
 		return $user_id;
 	}
 
+
+    /*
+     * Cleanup wp_options table upon user deletion in Wordpress
+     */
+    function um_delete_user_hook($id)
+    {
+        delete_option("um_cache_userdata_$id");
+    }
 }
+

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: Ultimate Member
 Plugin URI: http://ultimatemember.com/
 Description: The easiest way to create powerful online communities and beautiful user profiles with WordPress
-Version: 1.3.70
+Version: 1.3.71
 Author: Ultimate Member
 Author URI: http://ultimatemember.com/
 Text Domain: ultimatemember

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: Ultimate Member
 Plugin URI: http://ultimatemember.com/
 Description: The easiest way to create powerful online communities and beautiful user profiles with WordPress
-Version: 1.3.69
+Version: 1.3.70
 Author: Ultimate Member
 Author URI: http://ultimatemember.com/
 Text Domain: ultimatemember

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: access control, author, authors, author profile, comments, community, comm
 Requires at least: 4.1
 Tested up to: 4.6.1
 
-Stable Tag: 1.3.69
+Stable Tag: 1.3.70
 
 License: GNU Version 2 or Any Later Version
 
@@ -148,6 +148,15 @@ The plugin works with popular caching plugins by automatically excluding Ultimat
 16. Screenshot 16
 
 == Changelog ==
+
+= 1.3.70: September 09, 2016 =
+
+* Enhancements: 
+    * Adds a new filter hook to modify the profile `cover photo` uri.
+        * `um_user_cover_photo_uri__filter`
+* Bugfixes:
+    *  Fixes a bug to allow users change their password in account form
+
 
 = 1.3.69: September 08, 2016 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: access control, author, authors, author profile, comments, community, comm
 Requires at least: 4.1
 Tested up to: 4.6.1
 
-Stable Tag: 1.3.70
+Stable Tag: 1.3.71
 
 License: GNU Version 2 or Any Later Version
 
@@ -148,6 +148,16 @@ The plugin works with popular caching plugins by automatically excluding Ultimat
 16. Screenshot 16
 
 == Changelog ==
+
+= 1.3.71: September 12, 2016 =
+
+* Enhancements: 
+  * Adds a new filter hook to modify the `cover photo` uri.
+      * `um_user_cover_photo_uri__filter`
+* Bugfixes:
+  *  Fixes a bug to allow users change their password in account form
+  *  Fixes a bug to allow role validation and assigning of roles to users on registration process 
+  *  Fixes a bug to avoid blank admin footer text all around WordPress
 
 = 1.3.70: September 09, 2016 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -156,7 +156,7 @@ The plugin works with popular caching plugins by automatically excluding Ultimat
         * `um_user_cover_photo_uri__filter`
 * Bugfixes:
     *  Fixes a bug to allow users change their password in account form
-
+    *  Fixes a bug to reset passwords
 
 = 1.3.69: September 08, 2016 =
 


### PR DESCRIPTION

Currently options like um_cache_userdata_11 are not removed. Let's remove then upon user deletion
