### PR TITLE
Fixes notice when we use WP List Table quick edit

### DIFF
--- a/admin/core/um-admin-roles.php
+++ b/admin/core/um-admin-roles.php
@@ -11,8 +11,8 @@ class UM_Admin_Roles {
 	}
 
 	function remove_row_actions( $actions, $post ){
-	  global $current_screen, $ultimatemember;
-		if( $current_screen->post_type != 'um_role' ) return $actions;
+	  global $ultimatemember;
+		if( $post->post_type != 'um_role' ) return $actions;
 		
 		if( $ultimatemember->query->is_core( $post->ID ) ){
 			unset( $actions['trash'] );


### PR DESCRIPTION
Hi,

There is a little bug inside `remove_row_actions` function : when Ajax, $current_screen is not defined. So we can use the `$post` variable to determine if we are on the good post_type