### PR TITLE
Email Activation $user_login undefined, and wp_login action should pass 2 params

### DIFF
--- a/core/um-permalinks.php
+++ b/core/um-permalinks.php
@@ -181,11 +181,11 @@ class UM_Permalinks {
 					$user_id = $user->ID;
 
 					// update wp user
-					wp_set_current_user( $user_id, $user_login );
+					wp_set_current_user( $user_id, $user->user_login );
 					wp_set_auth_cookie( $user_id );
 
 					ob_start();
-					do_action( 'wp_login', $user_login );
+					do_action( 'wp_login', $user->user_login, $user );
 					ob_end_clean();
 				}
 


### PR DESCRIPTION
`$user_login` is not defined, should be `$user->user_login`, and `wp_login` action should pass two params, the `$user->user_login` and `$user` object just like core, otherwise will trigger fatal error for any custom filters on `wp_login` expecting the two params to be passed

Fixes #274