### PR TITLE
Fix error missing wp-load.php

### DIFF
--- a/core/lib/upload/um-image-upload.php
+++ b/core/lib/upload/um-image-upload.php
@@ -1,12 +1,24 @@
 <?php
 
-$i = 0;
 $dirname = dirname( __FILE__ );
 do {
 	$dirname = dirname( $dirname );
+	$wp_config = "{$dirname}/wp-config.php";
 	$wp_load = "{$dirname}/wp-load.php";
 }
-while( ++$i < 10 && !file_exists( $wp_load ) );
+while( !file_exists( $wp_config ) );
+
+if ( !file_exists( $wp_load ) ) {
+	$dirs = glob( $dirname . '/*' , GLOB_ONLYDIR );
+
+	foreach ($dirs as $key => $value) {
+		$wp_load = "{$value}/wp-load.php";
+		if ( file_exists( $wp_load ) ) {
+			break;
+		}
+	}
+}
+
 require_once( $wp_load );
 global $ultimatemember;
 


### PR DESCRIPTION
Fixing bug which require missing wp-load.php.

The new codes will traverse down until it found `wp-config.php`, then look for sibling `wp-load.php`. If not found/exist, it started to scan the directory with custom WordPress install such as `core/wp-load.php`, `wp/wp-load.php` until it found the file.

See ultimatemember#7