### PR TITLE
Fix save and query of privacy settings

### DIFF
--- a/core/um-actions-profile.php
+++ b/core/um-actions-profile.php
@@ -62,6 +62,8 @@
 		$userinfo = $ultimatemember->user->profile;
 
 		$fields = unserialize( $args['custom_fields'] );
+        $fields['profile_privacy'] = $args['profile_privacy'];
+        $fields['hide_in_members'] = $args['hide_in_members'];
 
 		do_action('um_user_before_updating_profile', $userinfo );
 

--- a/core/um-builtin.php
+++ b/core/um-builtin.php
@@ -1010,7 +1010,7 @@ class UM_Builtin {
 				'public' => 1,
 				'editable' => 1,
 				'default' => __('No','ultimate-member'),
-				'options' => array( __('No','ultimate-member'), __('Yes','ultimate-member') ),
+				'options' => array( array(__('No','ultimate-member'), 'false'), array(__('Yes','ultimate-member'), 'true') ),
 				'account_only' => true,
 				'required_opt' => array( 'members_page', 1 ),
 			),

--- a/core/um-fields.php
+++ b/core/um-fields.php
@@ -2079,10 +2079,16 @@ class UM_Fields {
 
 						foreach($options as $k => $v) {
 
-							$v = rtrim($v);
+						    if(is_array($v) && count($v) == 2) {
+							    $option_value = $v[1];
+						        $v = $v[0];
+                            } else {
+						        $option_value = $v;
+                            }
+
+						    $v = rtrim($v);
 
 							$um_field_checkbox_item_title = $v;
-							$option_value = $v;
 
 							if ( !is_numeric( $k ) && in_array($form_key, array('role') ) ) {
 								$um_field_checkbox_item_title = $v;

--- a/core/um-filters-members.php
+++ b/core/um-filters-members.php
@@ -63,7 +63,7 @@
 			    ),
 			    array(
 					'key' => 'hide_in_members',
-					'value' => 'Yes',
+					'value' => 'true',
 					'compare' => 'NOT LIKE'
 				)
 			);

--- a/core/um-filters-members.php
+++ b/core/um-filters-members.php
@@ -63,6 +63,19 @@
 			    ),
 			    array(
 					'key' => 'hide_in_members',
+					'value' => 'Yes',
+					'compare' => 'NOT LIKE'
+				)
+			);
+			$query_args['meta_query'][] = array(
+				"relation"	=> "OR",
+				array(
+						'key' => 'hide_in_members',
+						'value' => '',
+						'compare' => 'NOT EXISTS'
+			    ),
+			    array(
+					'key' => 'hide_in_members',
 					'value' => 'true',
 					'compare' => 'NOT LIKE'
 				)


### PR DESCRIPTION
Field hide_in_members was not saved at all. When saving, it was saved translated, i.e. changing the plugin language breaks the feature. 