### PR TITLE
Prevent guessing of profile/cover photo URLs

### DIFF
--- a/core/um-files.php
+++ b/core/um-files.php
@@ -557,6 +557,10 @@ class UM_Files {
 		// copy & overwrite file
 			
 		if( in_array( $key , array('profile_photo','cover_photo') ) ){
+			// Add a salted hash to the file extension so that the profile photo URLs are not guessable (salt is added inside wp_hash)
+			// This hash is later extracted by um_get_avatar_extension($filename) from the filename stored in the database under profile_photo.
+			// We could also use a random string instead of the hash, but then old images would not be deleted.
+			$ext = '.' . wp_hash('ultimate-member-photo-' . $user_id . '-' . $key) . $ext;
 			$filename = $key . $ext;
 			$name = $key;
 		}else{

--- a/core/um-short-functions.php
+++ b/core/um-short-functions.php
@@ -1357,7 +1357,7 @@
 	function um_get_cover_uri( $image, $attrs ) {
 		global $ultimatemember;
 		$uri = false;
-		$ext = '.' . pathinfo($image, PATHINFO_EXTENSION);
+		$ext = um_get_avatar_extension($image);
 		if ( file_exists( $ultimatemember->files->upload_basedir . um_user('ID') . '/cover_photo'.$ext ) ) {
 			$uri = um_user_uploads_uri() . 'cover_photo'.$ext.'?' . current_time( 'timestamp' );
 		}
@@ -1375,6 +1375,30 @@
 		return $matches[1];
 	}
 
+	/**
+	* @function um_get_avatar_extension()
+	*
+	* @description get file extension of avatar or cover photo
+	*
+	* @param $image (string) Image filename, path or URI, e.g., "/somewhere/something.extension.jpg"
+	*
+	* @returns File extension including dot prefixes, e.g., ".extension.jpg", or ".unknown" if it cannot be determined.
+	* Dot prefixes are included to allow for a secret hash against URL guessing (e.g., profile_photo.4242af1234.jpg).
+	*
+	* @note For backward compatibility with 1.3, this function must also work with plain filenames such as profile_photo.jpg without any prefixes.
+	**/
+	function um_get_avatar_extension($image) {
+		$last_slash = strrpos($image, "/"); // get start position of filename (/profile_photo.hash1234.jpg)
+		$first_dot_in_filename = strpos($image, ".", $last_slash); // get everything starting from the first dot (.hash1234.jpg)
+		if ($first_dot_in_filename === FALSE) {
+			// filename contains no dots -- empty string or invalid
+			$ext = ".unknown";
+		} else {
+			$ext = substr($image, $first_dot_in_filename);
+		}
+		return $ext;
+	}
+	
 	/***
 	***	@get avatar uri
 	***/
@@ -1382,7 +1406,7 @@
 		global $ultimatemember;
 		$uri = false;
 		$find = false;
-		$ext = '.' . pathinfo($image, PATHINFO_EXTENSION);
+		$ext = um_get_avatar_extension($image);
 
 		$cache_time = apply_filters('um_filter_avatar_cache_time', current_time( 'timestamp' ), um_user('ID') );
 		


### PR DESCRIPTION
As discussed #298, the the photo URLs were guessable and could therefore be downloaded without login: `ultimatemember/$id/profile_photo.jpg`

Now, a salted hash, which cannot be easily guessed, is added before the file extension: `ultimatemember/$id/profile_photo.$hash.jpg`
where $hash is something 'random' like 71e50739cb87c58295c1785608d27717, derived with wp_hash(), which uses MD5 HMAC and the random confguration variable AUTH_SALT. The hash is constant per user, so that old photos are overwritten.

This change is backwards-compatible -- previous profile photos still work. If you like, I can also port this to 2.0; I implemented it for 1.3.x as it is in the WP Plugin directory and we are using it on our website. I tested this patch as far as we use ultimatemember.

I'm looking forward to your feedback.