### PR TITLE
Overflow for cover image

### DIFF
--- a/assets/css/um-profile.css
+++ b/assets/css/um-profile.css
@@ -53,6 +53,7 @@
 	background-color: #eee;
 	box-sizing: border-box;
 	position: relative;
+	overflow: hidden;
 }
 
 .um-cover-add {


### PR DESCRIPTION
Without setting overflow:hidden to the cover images, big photos display over profile:
![image](https://user-images.githubusercontent.com/6459395/37096656-011529d8-2222-11e8-871b-2bc72da013b9.png)