### PR TITLE
Unnecessary use of untrailingslashit()

### DIFF
--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -368,7 +368,7 @@ if ( ! class_exists( 'um\core\Permalinks' ) ) {
 
 			if ( get_option('permalink_structure') ) {
 
-				$profile_url = trailingslashit( untrailingslashit( $profile_url ) );
+				$profile_url = trailingslashit( $profile_url );
 				$profile_url = $profile_url . strtolower( $slug ). '/';
 
 			} else {


### PR DESCRIPTION
According to the WordPress documentation, trailingslashit() unslashes the path before slashing it, in order to prevent a double slash at the end of the the string. For this reason, the use of untrailingslashit() inside trailingslashit() is redudant and, as such, unnecessary.