### PR TITLE
Fix grammar in activation link expiration message

### DIFF
--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -177,7 +177,7 @@ if ( ! class_exists( 'um\core\Permalinks' ) ) {
 				um_fetch_user( $user_id );
 
 				if (  strtolower($_REQUEST['hash']) !== strtolower( um_user('account_secret_hash') )  )
-					wp_die( __( 'This activation link is expired or have already been used.','ultimate-member' ) );
+					wp_die( __( 'This activation link is expired or has already been used.','ultimate-member' ) );
 
 				UM()->user()->approve();
 				$redirect = ( um_user('url_email_activate') ) ? um_user('url_email_activate') : um_get_core_page('login', 'account_active');


### PR DESCRIPTION
Fixes English grammar issues.