### PR TITLE
Fix max width issue with dynamic profile CSS

### DIFF
--- a/assets/dynamic_css/dynamic_profile.php
+++ b/assets/dynamic_css/dynamic_profile.php
@@ -5,7 +5,9 @@ $photosize = str_replace('px','',$photosize);
 $photosize_up = ( $photosize / 2 ) + 10;
 $meta_padding = ( $photosize + 60 ) . 'px';
 
-if ( $area_max_width ) {
+if ( isset($area_max_width) ) {
+    if(is_numeric($area_max_width))
+        $area_max_width.="px";
 print "
 .um-$form_id.um .um-profile-body {
 	max-width: $area_max_width;


### PR DESCRIPTION
Before, the width wasn't getting set, because the units weren't defined.
Picture from Chrome inspect element Styles view.
![image](https://user-images.githubusercontent.com/5914284/46189285-799bfa80-c2b3-11e8-995a-a7e4f4762c28.png)
After, units are being defined, and the page works as intended.
![image](https://user-images.githubusercontent.com/5914284/46189311-9fc19a80-c2b3-11e8-8a90-078e91b6004b.png)
