### PR TITLE
Allow to reset password for camelcased usernames

### DIFF
--- a/includes/core/class-password.php
+++ b/includes/core/class-password.php
@@ -500,7 +500,7 @@ if ( ! class_exists( 'um\core\Password' ) ) {
 			}
 
 			if ( username_exists( $user ) ) {
-				$data = get_user_by( 'login', $user );
+				$data = get_user_by( 'login', sanitize_user( wp_unslash( $user ) ) );
 			} elseif ( email_exists( $user ) ) {
 				$data = get_user_by( 'email', $user );
 			}


### PR DESCRIPTION
Follow Wordpress user sanitization to allow to restore the passwords if the username is camelcased (but login is not due to wordpress internal `add_filter( 'sanitize_user', 'strtolower' );`

fixes an issues where using "MyLogin" in password reset form input will never send an email but a successful redirect will be performed

## How to test:
1. make a user with
username: MyLogin
login: mylogin

2. try to reset password for `MyLogin`