### PR TITLE
remove html from default lock text as it gets escaped as per 2.0.54

### DIFF
--- a/includes/core/class-shortcodes.php
+++ b/includes/core/class-shortcodes.php
@@ -355,7 +355,7 @@ if ( ! class_exists( 'um\core\Shortcodes' ) ) {
 			ob_start();
 
 			$defaults = array(
-				'lock_text' => __( 'This content has been restricted to logged in users only. Please <a href="{login_referrer}">login</a> to view this content.', 'ultimate-member' ),
+				'lock_text' => __( 'This content has been restricted to logged in users only. Please login at the following link to view this content: {login_referrer}.', 'ultimate-member' ),				
 				'show_lock' => 'yes',
 			);
 


### PR DESCRIPTION
Since all html gets escaped in lock-text to protect against xss, I've removed the existing html from the current default lock-text