### PR TITLE
Fix jQuery 3 compatibility honeypot

### DIFF
--- a/includes/core/um-actions-global.php
+++ b/includes/core/um-actions-global.php
@@ -57,7 +57,7 @@ add_action( 'wp_head', 'um_add_form_honeypot_css' );
 function um_add_form_honeypot_js() {
 	?>
 		<script type="text/javascript">
-			jQuery(window).load(function() {
+			jQuery(window).on("load", function(e) {
 				jQuery("input[name='<?php echo esc_js( UM()->honeypot ); ?>']").val('');
 			});
 		</script>


### PR DESCRIPTION
When using jQuery 3 with Ultimate Member an error appears in the users console since [March 2nd](https://github.com/ultimatemember/ultimatemember/commit/75a04aaa85d05dc3d094a6afd8318065c0917b23):
> Uncaught TypeError: e.indexOf is not a function at w.fn.init.w.fn.load

This change adds compatibility for jQuery 3 users as per the [official upgrade guide](https://jquery.com/upgrade-guide/3.0/#breaking-change-load-unload-and-error-removed).