### PR TITLE
updating redirect_to action on registration

### DIFF
--- a/includes/core/um-actions-register.php
+++ b/includes/core/um-actions-register.php
@@ -177,6 +177,10 @@ function um_check_user_status( $user_id, $args ) {
 
 		// Priority redirect
 		if ( isset( $args['redirect_to'] ) ) {
+			if ( $status == 'approved' ) {
+				UM()->user()->auto_login( $user_id );
+				UM()->user()->generate_profile_slug( $user_id );
+			}
 			exit( wp_safe_redirect( urldecode( $args['redirect_to'] ) ) );
 		}
 


### PR DESCRIPTION
If you use redirect_to on the registration page, still enable it to auto log you in, etc. See this issue: https://github.com/ultimatemember/ultimatemember/issues/665