### PR TITLE
Fix: This is not possible for security reasons

### DIFF
--- a/includes/core/class-form.php
+++ b/includes/core/class-form.php
@@ -390,7 +390,11 @@ if ( ! class_exists( 'um\core\Form' ) ) {
 								return 'um_' . $item;
 							}, get_option( 'um_roles', array() ) );
 							$exclude_roles = array_diff( array_keys( $wp_roles->roles ), array_merge( $role_keys, array( 'subscriber' ) ) );
-
+							
+							$custom_field_roles = array_map( function( $item ) {
+								return 'um_' . strtolower($item);
+							}, $custom_field_roles );
+							
 							if ( ! empty( $role ) &&
 								( ! in_array( $role, $custom_field_roles, true ) || in_array( $role, $exclude_roles ) ) ) {
 								wp_die( __( 'This is not possible for security reasons.', 'ultimate-member' ) );


### PR DESCRIPTION
This change solves the "_This is not possible for security reasons_" issue and properly checks for the invalid Role entry during registration form submit.
**in_array()** check has a problem. Its comparing existing **$custom_field_roles** array value like um_customrole to CustomRole.
This update fixes **$custom_field_roles** values before check.

Thank you.