### PR TITLE
Adding a date picker translation file for Canadian french

### DIFF
--- a/assets/js/pickadate/translations/fr_CA.js
+++ b/assets/js/pickadate/translations/fr_CA.js
@@ -1,0 +1,23 @@
+// French (Canada)
+
+jQuery.extend( jQuery.fn.pickadate.defaults, {
+    monthsFull: [ 'Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin', 'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre' ],
+    monthsShort: [ 'Jan', 'Fev', 'Mar', 'Avr', 'Mai', 'Juin', 'Juil', 'Aou', 'Sep', 'Oct', 'Nov', 'Dec' ],
+    weekdaysFull: [ 'Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi' ],
+    weekdaysShort: [ 'Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam' ],
+    today: 'Aujourd\'hui',
+    clear: 'Effacer',
+    close: 'Fermer',
+    firstDay: 1,
+    format: 'dd mmmm yyyy',
+    formatSubmit: 'yyyy/mm/dd',
+    labelMonthNext:"Mois suivant",
+    labelMonthPrev:"Mois précédent",
+    labelMonthSelect:"Sélectionner un mois",
+    labelYearSelect:"Sélectionner une année"
+});
+
+jQuery.extend( jQuery.fn.pickatime.defaults, {
+    clear: 'Effacer',
+    format: 'H:i'
+});


### PR DESCRIPTION
The date picker is in English if the language of the website is set to Canadian french (fr_CA). The new translation file fixes the issue.