### PR TITLE
Ability to filter um_is_core_page() returned value

### DIFF
--- a/includes/um-short-functions.php
+++ b/includes/um-short-functions.php
@@ -14,9 +14,9 @@
  * @return string
  */
 function um_trim_string( $s, $length = 20 ) {
-	$s = strlen( $s ) > $length ? substr( $s, 0, $length ) . "..." : $s;
+    $s = strlen( $s ) > $length ? substr( $s, 0, $length ) . "..." : $s;
 
-	return $s;
+    return $s;
 }
 
 
@@ -29,17 +29,17 @@ function um_trim_string( $s, $length = 20 ) {
  */
 function um_dynamic_login_page_redirect( $redirect_to = '' ) {
 
-	$uri = um_get_core_page( 'login' );
+    $uri = um_get_core_page( 'login' );
 
-	if (!$redirect_to) {
-		$redirect_to = UM()->permalinks()->get_current_url();
-	}
+    if (!$redirect_to) {
+        $redirect_to = UM()->permalinks()->get_current_url();
+    }
 
-	$redirect_key = urlencode_deep( $redirect_to );
+    $redirect_key = urlencode_deep( $redirect_to );
 
-	$uri = add_query_arg( 'redirect_to', $redirect_key, $uri );
+    $uri = add_query_arg( 'redirect_to', $redirect_key, $uri );
 
-	return $uri;
+    return $uri;
 }
 
 
@@ -50,15 +50,15 @@ function um_dynamic_login_page_redirect( $redirect_to = '' ) {
  */
 function um_is_session_started() {
 
-	if ( php_sapi_name() !== 'cli' ) {
-		if ( version_compare( phpversion(), '5.4.0', '>=' ) ) {
-			return session_status() === PHP_SESSION_ACTIVE ? true : false;
-		} else {
-			return session_id() === '' ? false : true;
-		}
-	}
+    if ( php_sapi_name() !== 'cli' ) {
+        if ( version_compare( phpversion(), '5.4.0', '>=' ) ) {
+            return session_status() === PHP_SESSION_ACTIVE ? true : false;
+        } else {
+            return session_id() === '' ? false : true;
+        }
+    }
 
-	return false;
+    return false;
 }
 
 /**
@@ -70,35 +70,35 @@ function um_is_session_started() {
  */
 function um_clean_user_basename( $value ) {
 
-	$raw_value = $value;
-	$value = str_replace( '.', ' ', $value );
-	$value = str_replace( '-', ' ', $value );
-	$value = str_replace( '+', ' ', $value );
+    $raw_value = $value;
+    $value = str_replace( '.', ' ', $value );
+    $value = str_replace( '-', ' ', $value );
+    $value = str_replace( '+', ' ', $value );
 
-	/**
-	 * UM hook
-	 *
-	 * @type filter
-	 * @title um_clean_user_basename_filter
-	 * @description Change clean user basename
-	 * @input_vars
-	 * [{"var":"$basename","type":"string","desc":"User basename"},
-	 * {"var":"$raw_basename","type":"string","desc":"RAW user basename"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_clean_user_basename_filter', 'function_name', 10, 2 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_clean_user_basename_filter', 'my_clean_user_basename', 10, 2 );
-	 * function my_clean_user_basename( $basename, $raw_basename ) {
-	 *     // your code here
-	 *     return $basename;
-	 * }
-	 * ?>
-	 */
-	$value = apply_filters( 'um_clean_user_basename_filter', $value, $raw_value );
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_clean_user_basename_filter
+     * @description Change clean user basename
+     * @input_vars
+     * [{"var":"$basename","type":"string","desc":"User basename"},
+     * {"var":"$raw_basename","type":"string","desc":"RAW user basename"}]
+     * @change_log
+     * ["Since: 2.0"]
+     * @usage add_filter( 'um_clean_user_basename_filter', 'function_name', 10, 2 );
+     * @example
+     * <?php
+     * add_filter( 'um_clean_user_basename_filter', 'my_clean_user_basename', 10, 2 );
+     * function my_clean_user_basename( $basename, $raw_basename ) {
+     *     // your code here
+     *     return $basename;
+     * }
+     * ?>
+     */
+    $value = apply_filters( 'um_clean_user_basename_filter', $value, $raw_value );
 
-	return $value;
+    return $value;
 }
 
 
@@ -109,76 +109,76 @@ function um_clean_user_basename( $value ) {
  */
 function um_replace_placeholders() {
 
-	$search = array(
-		'{display_name}',
-		'{first_name}',
-		'{last_name}',
-		'{gender}',
-		'{username}',
-		'{email}',
-		'{site_name}',
-		'{user_account_link}',
-	);
+    $search = array(
+        '{display_name}',
+        '{first_name}',
+        '{last_name}',
+        '{gender}',
+        '{username}',
+        '{email}',
+        '{site_name}',
+        '{user_account_link}',
+    );
 
 
-	/**
-	 * UM hook
-	 *
-	 * @type filter
-	 * @title um_template_tags_patterns_hook
-	 * @description Extend UM placeholders
-	 * @input_vars
-	 * [{"var":"$placeholders","type":"array","desc":"UM Placeholders"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_template_tags_patterns_hook', 'function_name', 10, 1 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_template_tags_patterns_hook', 'my_template_tags_patterns', 10, 1 );
-	 * function my_template_tags_patterns( $placeholders ) {
-	 *     // your code here
-	 *     $placeholders[] = '{my_custom_placeholder}';
-	 *     return $placeholders;
-	 * }
-	 * ?>
-	 */
-	$search = apply_filters( 'um_template_tags_patterns_hook', $search );
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_template_tags_patterns_hook
+     * @description Extend UM placeholders
+     * @input_vars
+     * [{"var":"$placeholders","type":"array","desc":"UM Placeholders"}]
+     * @change_log
+     * ["Since: 2.0"]
+     * @usage add_filter( 'um_template_tags_patterns_hook', 'function_name', 10, 1 );
+     * @example
+     * <?php
+     * add_filter( 'um_template_tags_patterns_hook', 'my_template_tags_patterns', 10, 1 );
+     * function my_template_tags_patterns( $placeholders ) {
+     *     // your code here
+     *     $placeholders[] = '{my_custom_placeholder}';
+     *     return $placeholders;
+     * }
+     * ?>
+     */
+    $search = apply_filters( 'um_template_tags_patterns_hook', $search );
 
-	$replace = array(
-		um_user( 'display_name' ),
-		um_user( 'first_name' ),
-		um_user( 'last_name' ),
-		um_user( 'gender' ),
-		um_user( 'user_login' ),
-		um_user( 'user_email' ),
-		UM()->options()->get( 'site_name' ),
-		um_get_core_page( 'account' ),
-	);
+    $replace = array(
+        um_user( 'display_name' ),
+        um_user( 'first_name' ),
+        um_user( 'last_name' ),
+        um_user( 'gender' ),
+        um_user( 'user_login' ),
+        um_user( 'user_email' ),
+        UM()->options()->get( 'site_name' ),
+        um_get_core_page( 'account' ),
+    );
 
-	/**
-	 * UM hook
-	 *
-	 * @type filter
-	 * @title um_template_tags_replaces_hook
-	 * @description Extend UM replace placeholders
-	 * @input_vars
-	 * [{"var":"$replace_placeholders","type":"array","desc":"UM Replace Placeholders"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_template_tags_replaces_hook', 'function_name', 10, 1 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_template_tags_replaces_hook', 'my_template_tags_replaces', 10, 1 );
-	 * function my_template_tags_replaces( $replace_placeholders ) {
-	 *     // your code here
-	 *     $replace_placeholders[] = 'my_replace_value';
-	 *     return $replace_placeholders;
-	 * }
-	 * ?>
-	 */
-	$replace = apply_filters( 'um_template_tags_replaces_hook', $replace );
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_template_tags_replaces_hook
+     * @description Extend UM replace placeholders
+     * @input_vars
+     * [{"var":"$replace_placeholders","type":"array","desc":"UM Replace Placeholders"}]
+     * @change_log
+     * ["Since: 2.0"]
+     * @usage add_filter( 'um_template_tags_replaces_hook', 'function_name', 10, 1 );
+     * @example
+     * <?php
+     * add_filter( 'um_template_tags_replaces_hook', 'my_template_tags_replaces', 10, 1 );
+     * function my_template_tags_replaces( $replace_placeholders ) {
+     *     // your code here
+     *     $replace_placeholders[] = 'my_replace_value';
+     *     return $replace_placeholders;
+     * }
+     * ?>
+     */
+    $replace = apply_filters( 'um_template_tags_replaces_hook', $replace );
 
-	return array_combine( $search, $replace );
+    return array_combine( $search, $replace );
 }
 
 
@@ -192,32 +192,32 @@ function um_replace_placeholders() {
  * @return mixed|string
  */
 function um_convert_tags( $content, $args = array(), $with_kses = true ) {
-	$placeholders = um_replace_placeholders();
+    $placeholders = um_replace_placeholders();
 
-	$content = str_replace( array_keys( $placeholders ), array_values( $placeholders ), $content );
-	if ( $with_kses ) {
-		$content = wp_kses_decode_entities( $content );
-	}
+    $content = str_replace( array_keys( $placeholders ), array_values( $placeholders ), $content );
+    if ( $with_kses ) {
+        $content = wp_kses_decode_entities( $content );
+    }
 
-	if ( isset( $args['tags'] ) && isset( $args['tags_replace'] ) ) {
-		$content = str_replace( $args['tags'], $args['tags_replace'], $content );
-	}
+    if ( isset( $args['tags'] ) && isset( $args['tags_replace'] ) ) {
+        $content = str_replace( $args['tags'], $args['tags_replace'], $content );
+    }
 
-	$regex = '~\{(usermeta:[^}]*)\}~';
-	preg_match_all( $regex, $content, $matches );
+    $regex = '~\{(usermeta:[^}]*)\}~';
+    preg_match_all( $regex, $content, $matches );
 
-	// Support for all usermeta keys
-	if ( ! empty( $matches[1] ) && is_array( $matches[1] ) ) {
-		foreach ( $matches[1] as $match ) {
-			$key = str_replace( 'usermeta:', '', $match );
-			$value = um_user( $key );
-			if ( is_array( $value ) ) {
-				$value = implode( ', ', $value );
-			}
-			$content = str_replace( '{' . $match . '}', apply_filters( 'um_convert_tags', $value, $key ), $content );
-		}
-	}
-	return $content;
+    // Support for all usermeta keys
+    if ( ! empty( $matches[1] ) && is_array( $matches[1] ) ) {
+        foreach ( $matches[1] as $match ) {
+            $key = str_replace( 'usermeta:', '', $match );
+            $value = um_user( $key );
+            if ( is_array( $value ) ) {
+                $value = implode( ', ', $value );
+            }
+            $content = str_replace( '{' . $match . '}', apply_filters( 'um_convert_tags', $value, $key ), $content );
+        }
+    }
+    return $content;
 }
 
 
@@ -229,8 +229,8 @@ function um_convert_tags( $content, $args = array(), $with_kses = true ) {
  * @return array
  */
 function account_activation_link_tags_patterns( $placeholders ) {
-	$placeholders[] = '{account_activation_link}';
-	return $placeholders;
+    $placeholders[] = '{account_activation_link}';
+    return $placeholders;
 }
 
 /**
@@ -241,8 +241,8 @@ function account_activation_link_tags_patterns( $placeholders ) {
  * @return array
  */
 function account_activation_link_tags_replaces( $replace_placeholders ) {
-	$replace_placeholders[] = um_user( 'account_activation_link' );
-	return $replace_placeholders;
+    $replace_placeholders[] = um_user( 'account_activation_link' );
+    return $replace_placeholders;
 }
 
 
@@ -265,39 +265,39 @@ function account_activation_link_tags_replaces( $replace_placeholders ) {
  * ?>
  */
 function um_user_ip() {
-	$ip = '127.0.0.1';
+    $ip = '127.0.0.1';
 
-	if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ) {
-		//check ip from share internet
-		$ip = $_SERVER['HTTP_CLIENT_IP'];
-	} else if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-		//to check ip is pass from proxy
-		$ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
-	} else if ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
-		$ip = $_SERVER['REMOTE_ADDR'];
-	}
+    if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ) {
+        //check ip from share internet
+        $ip = $_SERVER['HTTP_CLIENT_IP'];
+    } else if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+        //to check ip is pass from proxy
+        $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+    } else if ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+        $ip = $_SERVER['REMOTE_ADDR'];
+    }
 
-	/**
-	 * UM hook
-	 *
-	 * @type filter
-	 * @title um_user_ip
-	 * @description Change User IP
-	 * @input_vars
-	 * [{"var":"$ip","type":"string","desc":"User IP"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_user_ip', 'function_name', 10, 1 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_user_ip', 'my_user_ip', 10, 1 );
-	 * function my_user_ip( $ip ) {
-	 *     // your code here
-	 *     return $ip;
-	 * }
-	 * ?>
-	 */
-	return apply_filters( 'um_user_ip', $ip );
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_user_ip
+     * @description Change User IP
+     * @input_vars
+     * [{"var":"$ip","type":"string","desc":"User IP"}]
+     * @change_log
+     * ["Since: 2.0"]
+     * @usage add_filter( 'um_user_ip', 'function_name', 10, 1 );
+     * @example
+     * <?php
+     * add_filter( 'um_user_ip', 'my_user_ip', 10, 1 );
+     * function my_user_ip( $ip ) {
+     *     // your code here
+     *     return $ip;
+     * }
+     * ?>
+     */
+    return apply_filters( 'um_user_ip', $ip );
 }
 
 
@@ -310,290 +310,290 @@ function um_user_ip() {
  */
 function um_field_conditions_are_met( $data ) {
 
-	if ( ! isset( $data['conditions'] ) ) {
-		return true;
-	}
+    if ( ! isset( $data['conditions'] ) ) {
+        return true;
+    }
 
-	$state = ( isset( $data['conditional_action'] ) && $data['conditional_action'] == 'show' ) ? 1 : 0;
+    $state = ( isset( $data['conditional_action'] ) && $data['conditional_action'] == 'show' ) ? 1 : 0;
 
-	$first_group = 0;
-	$state_array = array();
-	$count = count( $state_array );
-	foreach ( $data['conditions'] as $k => $arr ) {
+    $first_group = 0;
+    $state_array = array();
+    $count = count( $state_array );
+    foreach ( $data['conditions'] as $k => $arr ) {
 
-		$val = $arr[3];
-		$op = $arr[2];
+        $val = $arr[3];
+        $op = $arr[2];
 
-		if ( strstr( $arr[1], 'role_' ) ) {
-			$arr[1] = 'role';
-		}
+        if ( strstr( $arr[1], 'role_' ) ) {
+            $arr[1] = 'role';
+        }
 
-		$field = um_profile( $arr[1] );
-
-
-		if ( ! isset( $arr[5] ) || $arr[5] != $first_group ) {
+        $field = um_profile( $arr[1] );
 
 
-			if ( $arr[0] == 'show' ) {
-
-				switch ($op) {
-					case 'equals to':
-
-						$field = maybe_unserialize( $field );
-
-						if (is_array( $field ))
-							$state = in_array( $val, $field ) ? 'show' : 'hide';
-						else
-							$state = ( $field == $val ) ? 'show' : 'hide';
-
-						break;
-					case 'not equals':
-
-						$field = maybe_unserialize( $field );
-
-						if (is_array( $field ))
-							$state = !in_array( $val, $field ) ? 'show' : 'hide';
-						else
-							$state = ( $field != $val ) ? 'show' : 'hide';
-
-						break;
-					case 'empty':
-
-						$state = ( !$field ) ? 'show' : 'hide';
-
-						break;
-					case 'not empty':
-
-						$state = ( $field ) ? 'show' : 'hide';
-
-						break;
-					case 'greater than':
-						if ($field > $val) {
-							$state = 'show';
-						} else {
-							$state = 'hide';
-						}
-						break;
-					case 'less than':
-						if ($field < $val) {
-							$state = 'show';
-						} else {
-							$state = 'hide';
-						}
-						break;
-					case 'contains':
-						if (strstr( $field, $val )) {
-							$state = 'show';
-						} else {
-							$state = 'hide';
-						}
-						break;
-				}
-			} elseif ( $arr[0] == 'hide' ) {
-
-				switch ( $op ) {
-					case 'equals to':
-
-						$field = maybe_unserialize( $field );
-
-						if ( is_array( $field ) ) {
-							$state = in_array( $val, $field ) ? 'hide' : 'show';
-						} else {
-							$state = ( $field == $val ) ? 'hide' : 'show';
-						}
-
-						break;
-					case 'not equals':
-
-						$field = maybe_unserialize( $field );
-
-						if ( is_array( $field ) ) {
-							$state = ! in_array( $val, $field ) ? 'hide' : 'show';
-						} else {
-							$state = ( $field != $val ) ? 'hide' : 'show';
-						}
-
-						break;
-					case 'empty':
-
-						$state = ( ! $field ) ? 'hide' : 'show';
-
-						break;
-					case 'not empty':
-
-						$state = ( $field ) ? 'hide' : 'show';
-
-						break;
-					case 'greater than':
-						if ( $field <= $val ) {
-							$state = 'hide';
-						} else {
-							$state = 'show';
-						}
-						break;
-					case 'less than':
-						if ( $field >= $val ) {
-							$state = 'hide';
-						} else {
-							$state = 'show';
-						}
-						break;
-					case 'contains':
-						if ( strstr( $field, $val ) ) {
-							$state = 'hide';
-						} else {
-							$state = 'show';
-						}
-						break;
-				}
-			}
-			$first_group++;
-			array_push( $state_array, $state );
-		} else {
-
-			if ( $arr[0] == 'show' ) {
-
-				switch ( $op ) {
-					case 'equals to':
-						$field = maybe_unserialize( $field );
-
-						if ( is_array( $field ) ) {
-							$state = in_array( $val, $field ) ? 'show' : 'not_show';
-						} else {
-							$state = ( $field == $val ) ? 'show' : 'not_show';
-						}
-
-						break;
-					case 'not equals':
-						$field = maybe_unserialize( $field );
-
-						if ( is_array( $field ) ) {
-							$state = ! in_array( $val, $field ) ? 'show' : 'not_show';
-						} else {
-							$state = ( $field != $val ) ? 'show' : 'not_show';
-						}
-
-						break;
-					case 'empty':
-
-						$state = ( ! $field ) ? 'show' : 'not_show';
-
-						break;
-					case 'not empty':
-
-						$state = ( $field ) ? 'show': 'not_show';
-
-						break;
-					case 'greater than':
-						if ( $field > $val ) {
-							$state = 'show';
-						} else {
-							$state = 'not_show';
-						}
-						break;
-					case 'less than':
-						if ( $field < $val ) {
-							$state = 'show';
-						} else {
-							$state = 'not_show';
-						}
-						break;
-					case 'contains':
-						if ( strstr( $field, $val ) ) {
-							$state = 'show';
-						} else {
-							$state = 'not_show';
-						}
-						break;
-				}
-			} elseif ( $arr[0] == 'hide' ) {
-
-				switch ( $op ) {
-					case 'equals to':
-						$field = maybe_unserialize( $field );
-
-						if ( is_array( $field ) ) {
-							$state = in_array( $val, $field ) ? 'hide' : 'not_hide';
-						} else {
-							$state = ( $field == $val ) ? 'hide' : 'not_hide';
-						}
-
-						break;
-					case 'not equals':
-
-						$field = maybe_unserialize( $field );
-
-						if ( is_array( $field ) ) {
-							$state = ! in_array( $val, $field ) ? 'hide' : 'not_hide';
-						} else {
-							$state = ( $field != $val ) ? 'hide' : 'not_hide';
-						}
-
-						break;
-					case 'empty':
-
-						$state = ( ! $field ) ? 'hide' : 'not_hide';
-
-						break;
-					case 'not empty':
-
-						$state = ( $field ) ? 'hide' : 'not_hide';
-
-						break;
-					case 'greater than':
-						if ( $field <= $val ) {
-							$state = 'hide';
-						} else {
-							$state = 'not_hide';
-						}
-						break;
-					case 'less than':
-						if ( $field >= $val ) {
-							$state = 'hide';
-						} else {
-							$state = 'not_hide';
-						}
-						break;
-					case 'contains':
-						if ( strstr( $field, $val ) ) {
-							$state = 'hide';
-						} else {
-							$state = 'not_hide';
-						}
-						break;
-				}
-			}
-			if ( isset( $state_array[ $count ] ) ) {
-				if ( $state_array[ $count ] == 'show' || $state_array[ $count ] == 'not_hide' ) {
-					if ( $state == 'show' || $state == 'not_hide' ) {
-						$state_array[ $count ] = 'show';
-					} else {
-						$state_array[ $count ] = 'hide';
-					}
-				} else {
-					if ( $state == 'hide' || $state == 'not_show' ) {
-						$state_array[ $count ] = 'hide';
-					} else {
-						$state_array[ $count ] = 'hide';
-					}
-				}
-			} else {
-				if ( $state == 'show' || $state == 'not_hide' ) {
-					$state_array[ $count ] = 'show';
-				} else {
-					$state_array[ $count ] = 'hide';
-				}
-			}
-		}
+        if ( ! isset( $arr[5] ) || $arr[5] != $first_group ) {
 
 
-	}
-	$result = array_unique( $state_array );
-	if ( ! in_array( 'show', $result ) ) {
-		return $state = false;
-	} else {
-		return $state = true;
-	}
+            if ( $arr[0] == 'show' ) {
+
+                switch ($op) {
+                    case 'equals to':
+
+                        $field = maybe_unserialize( $field );
+
+                        if (is_array( $field ))
+                            $state = in_array( $val, $field ) ? 'show' : 'hide';
+                        else
+                            $state = ( $field == $val ) ? 'show' : 'hide';
+
+                        break;
+                    case 'not equals':
+
+                        $field = maybe_unserialize( $field );
+
+                        if (is_array( $field ))
+                            $state = !in_array( $val, $field ) ? 'show' : 'hide';
+                        else
+                            $state = ( $field != $val ) ? 'show' : 'hide';
+
+                        break;
+                    case 'empty':
+
+                        $state = ( !$field ) ? 'show' : 'hide';
+
+                        break;
+                    case 'not empty':
+
+                        $state = ( $field ) ? 'show' : 'hide';
+
+                        break;
+                    case 'greater than':
+                        if ($field > $val) {
+                            $state = 'show';
+                        } else {
+                            $state = 'hide';
+                        }
+                        break;
+                    case 'less than':
+                        if ($field < $val) {
+                            $state = 'show';
+                        } else {
+                            $state = 'hide';
+                        }
+                        break;
+                    case 'contains':
+                        if (strstr( $field, $val )) {
+                            $state = 'show';
+                        } else {
+                            $state = 'hide';
+                        }
+                        break;
+                }
+            } elseif ( $arr[0] == 'hide' ) {
+
+                switch ( $op ) {
+                    case 'equals to':
+
+                        $field = maybe_unserialize( $field );
+
+                        if ( is_array( $field ) ) {
+                            $state = in_array( $val, $field ) ? 'hide' : 'show';
+                        } else {
+                            $state = ( $field == $val ) ? 'hide' : 'show';
+                        }
+
+                        break;
+                    case 'not equals':
+
+                        $field = maybe_unserialize( $field );
+
+                        if ( is_array( $field ) ) {
+                            $state = ! in_array( $val, $field ) ? 'hide' : 'show';
+                        } else {
+                            $state = ( $field != $val ) ? 'hide' : 'show';
+                        }
+
+                        break;
+                    case 'empty':
+
+                        $state = ( ! $field ) ? 'hide' : 'show';
+
+                        break;
+                    case 'not empty':
+
+                        $state = ( $field ) ? 'hide' : 'show';
+
+                        break;
+                    case 'greater than':
+                        if ( $field <= $val ) {
+                            $state = 'hide';
+                        } else {
+                            $state = 'show';
+                        }
+                        break;
+                    case 'less than':
+                        if ( $field >= $val ) {
+                            $state = 'hide';
+                        } else {
+                            $state = 'show';
+                        }
+                        break;
+                    case 'contains':
+                        if ( strstr( $field, $val ) ) {
+                            $state = 'hide';
+                        } else {
+                            $state = 'show';
+                        }
+                        break;
+                }
+            }
+            $first_group++;
+            array_push( $state_array, $state );
+        } else {
+
+            if ( $arr[0] == 'show' ) {
+
+                switch ( $op ) {
+                    case 'equals to':
+                        $field = maybe_unserialize( $field );
+
+                        if ( is_array( $field ) ) {
+                            $state = in_array( $val, $field ) ? 'show' : 'not_show';
+                        } else {
+                            $state = ( $field == $val ) ? 'show' : 'not_show';
+                        }
+
+                        break;
+                    case 'not equals':
+                        $field = maybe_unserialize( $field );
+
+                        if ( is_array( $field ) ) {
+                            $state = ! in_array( $val, $field ) ? 'show' : 'not_show';
+                        } else {
+                            $state = ( $field != $val ) ? 'show' : 'not_show';
+                        }
+
+                        break;
+                    case 'empty':
+
+                        $state = ( ! $field ) ? 'show' : 'not_show';
+
+                        break;
+                    case 'not empty':
+
+                        $state = ( $field ) ? 'show': 'not_show';
+
+                        break;
+                    case 'greater than':
+                        if ( $field > $val ) {
+                            $state = 'show';
+                        } else {
+                            $state = 'not_show';
+                        }
+                        break;
+                    case 'less than':
+                        if ( $field < $val ) {
+                            $state = 'show';
+                        } else {
+                            $state = 'not_show';
+                        }
+                        break;
+                    case 'contains':
+                        if ( strstr( $field, $val ) ) {
+                            $state = 'show';
+                        } else {
+                            $state = 'not_show';
+                        }
+                        break;
+                }
+            } elseif ( $arr[0] == 'hide' ) {
+
+                switch ( $op ) {
+                    case 'equals to':
+                        $field = maybe_unserialize( $field );
+
+                        if ( is_array( $field ) ) {
+                            $state = in_array( $val, $field ) ? 'hide' : 'not_hide';
+                        } else {
+                            $state = ( $field == $val ) ? 'hide' : 'not_hide';
+                        }
+
+                        break;
+                    case 'not equals':
+
+                        $field = maybe_unserialize( $field );
+
+                        if ( is_array( $field ) ) {
+                            $state = ! in_array( $val, $field ) ? 'hide' : 'not_hide';
+                        } else {
+                            $state = ( $field != $val ) ? 'hide' : 'not_hide';
+                        }
+
+                        break;
+                    case 'empty':
+
+                        $state = ( ! $field ) ? 'hide' : 'not_hide';
+
+                        break;
+                    case 'not empty':
+
+                        $state = ( $field ) ? 'hide' : 'not_hide';
+
+                        break;
+                    case 'greater than':
+                        if ( $field <= $val ) {
+                            $state = 'hide';
+                        } else {
+                            $state = 'not_hide';
+                        }
+                        break;
+                    case 'less than':
+                        if ( $field >= $val ) {
+                            $state = 'hide';
+                        } else {
+                            $state = 'not_hide';
+                        }
+                        break;
+                    case 'contains':
+                        if ( strstr( $field, $val ) ) {
+                            $state = 'hide';
+                        } else {
+                            $state = 'not_hide';
+                        }
+                        break;
+                }
+            }
+            if ( isset( $state_array[ $count ] ) ) {
+                if ( $state_array[ $count ] == 'show' || $state_array[ $count ] == 'not_hide' ) {
+                    if ( $state == 'show' || $state == 'not_hide' ) {
+                        $state_array[ $count ] = 'show';
+                    } else {
+                        $state_array[ $count ] = 'hide';
+                    }
+                } else {
+                    if ( $state == 'hide' || $state == 'not_show' ) {
+                        $state_array[ $count ] = 'hide';
+                    } else {
+                        $state_array[ $count ] = 'hide';
+                    }
+                }
+            } else {
+                if ( $state == 'show' || $state == 'not_hide' ) {
+                    $state_array[ $count ] = 'show';
+                } else {
+                    $state_array[ $count ] = 'hide';
+                }
+            }
+        }
+
+
+    }
+    $result = array_unique( $state_array );
+    if ( ! in_array( 'show', $result ) ) {
+        return $state = false;
+    } else {
+        return $state = true;
+    }
 }
 
 
@@ -604,8 +604,8 @@ function um_field_conditions_are_met( $data ) {
  * @param string $is_my_profile
  */
 function um_redirect_home( $requested_user_id = '', $is_my_profile = '' ) {
-	$url = apply_filters( 'um_redirect_home_custom_url', home_url(), $requested_user_id, $is_my_profile );
-	exit( wp_redirect( $url ) );
+    $url = apply_filters( 'um_redirect_home_custom_url', home_url(), $requested_user_id, $is_my_profile );
+    exit( wp_redirect( $url ) );
 }
 
 
@@ -614,29 +614,29 @@ function um_redirect_home( $requested_user_id = '', $is_my_profile = '' ) {
  * @param $url
  */
 function um_js_redirect( $url ) {
-	if ( headers_sent() || empty( $url ) ) {
-		//for blank redirects
-		if ( '' == $url ) {
-			$url = set_url_scheme( '//' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"] );
-		}
+    if ( headers_sent() || empty( $url ) ) {
+        //for blank redirects
+        if ( '' == $url ) {
+            $url = set_url_scheme( '//' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"] );
+        }
 
-		register_shutdown_function( function( $url ) {
-			echo '<script data-cfasync="false" type="text/javascript">window.location = "' . esc_js( $url ) . '"</script>';
-		}, $url );
+        register_shutdown_function( function( $url ) {
+            echo '<script data-cfasync="false" type="text/javascript">window.location = "' . esc_js( $url ) . '"</script>';
+        }, $url );
 
-		if ( 1 < ob_get_level() ) {
-			while ( ob_get_level() > 1 ) {
-				ob_end_clean();
-			}
-		} ?>
-		<script data-cfasync='false' type="text/javascript">
-			window.location = '<?php echo esc_js( $url ); ?>';
-		</script>
-		<?php exit;
-	} else {
-		wp_redirect( $url );
-	}
-	exit;
+        if ( 1 < ob_get_level() ) {
+            while ( ob_get_level() > 1 ) {
+                ob_end_clean();
+            }
+        } ?>
+        <script data-cfasync='false' type="text/javascript">
+            window.location = '<?php echo esc_js( $url ); ?>';
+        </script>
+        <?php exit;
+    } else {
+        wp_redirect( $url );
+    }
+    exit;
 }
 
 
@@ -649,179 +649,179 @@ function um_js_redirect( $url ) {
  * @return string
  */
 function um_get_snippet( $str, $wordCount = 10 ) {
-	if (str_word_count( $str, 0, "éèàôù" ) > $wordCount) {
-		$str = implode(
-			'',
-			array_slice(
-				preg_split(
-					'/([\s,\.;\?\!]+)/',
-					$str,
-					$wordCount * 2 + 1,
-					PREG_SPLIT_DELIM_CAPTURE
-				),
-				0,
-				$wordCount * 2 - 1
-			)
-		);
-	}
+    if (str_word_count( $str, 0, "éèàôù" ) > $wordCount) {
+        $str = implode(
+            '',
+            array_slice(
+                preg_split(
+                    '/([\s,\.;\?\!]+)/',
+                    $str,
+                    $wordCount * 2 + 1,
+                    PREG_SPLIT_DELIM_CAPTURE
+                ),
+                0,
+                $wordCount * 2 - 1
+            )
+        );
+    }
 
-	return $str;
+    return $str;
 }
 
 
 /**
  * Format submitted data for Info preview & Email template
- * @param  boolean $style 
+ * @param  boolean $style
  * @return string
  *
- * @since  2.1.4 
+ * @since  2.1.4
  */
 function um_user_submitted_registration_formatted( $style = false ) {
-	$output = null;
+    $output = null;
 
-	$submitted_data = um_user( 'submitted' );
+    $submitted_data = um_user( 'submitted' );
 
-	if ( $style ) {
-		$output .= '<div class="um-admin-infobox">';
-	}
+    if ( $style ) {
+        $output .= '<div class="um-admin-infobox">';
+    }
 
-	// Timestamp
-	$output .= um_user_submited_display( 'timestamp', __( 'Date Submitted', 'ultimate-member' ) );
-	$output .= um_user_submited_display( 'form_id', __( 'Form', 'ultimate-member' ), $submitted_data );
+    // Timestamp
+    $output .= um_user_submited_display( 'timestamp', __( 'Date Submitted', 'ultimate-member' ) );
+    $output .= um_user_submited_display( 'form_id', __( 'Form', 'ultimate-member' ), $submitted_data );
 
-	if ( isset( $submitted_data ) && is_array( $submitted_data ) ) {
+    if ( isset( $submitted_data ) && is_array( $submitted_data ) ) {
 
-		if ( isset( $submitted_data['form_id'] ) ) {
-			$fields = UM()->query()->get_attr( 'custom_fields', $submitted_data['form_id'] );
-		}
+        if ( isset( $submitted_data['form_id'] ) ) {
+            $fields = UM()->query()->get_attr( 'custom_fields', $submitted_data['form_id'] );
+        }
 
-		if ( isset( $fields ) ) {
+        if ( isset( $fields ) ) {
 
-			$fields['form_id'] = array( 'title' => __( 'Form', 'ultimate-member' ) );
+            $fields['form_id'] = array( 'title' => __( 'Form', 'ultimate-member' ) );
 
-			$rows = array();
+            $rows = array();
 
-			UM()->fields()->get_fields = $fields;
+            UM()->fields()->get_fields = $fields;
 
-			foreach ( $fields as $key => $array ) {
-				if ( isset( $array['type'] ) && $array['type'] == 'row' ) {
-					$rows[ $key ] = $array;
-					unset( UM()->fields()->get_fields[ $key ] ); // not needed now
-				}
-			}
+            foreach ( $fields as $key => $array ) {
+                if ( isset( $array['type'] ) && $array['type'] == 'row' ) {
+                    $rows[ $key ] = $array;
+                    unset( UM()->fields()->get_fields[ $key ] ); // not needed now
+                }
+            }
 
-			if ( empty( $rows ) ) {
-				$rows = array(
-					'_um_row_1' => array(
-						'type'      => 'row',
-						'id'        => '_um_row_1',
-						'sub_rows'  => 1,
-						'cols'      => 1
-					),
-				);
-			}
+            if ( empty( $rows ) ) {
+                $rows = array(
+                    '_um_row_1' => array(
+                        'type'      => 'row',
+                        'id'        => '_um_row_1',
+                        'sub_rows'  => 1,
+                        'cols'      => 1
+                    ),
+                );
+            }
 
-			foreach ( $rows as $row_id => $row_array ) {
+            foreach ( $rows as $row_id => $row_array ) {
 
-				$row_fields = UM()->fields()->get_fields_by_row( $row_id );
+                $row_fields = UM()->fields()->get_fields_by_row( $row_id );
 
-				if ( $row_fields ) {
+                if ( $row_fields ) {
 
-					$output .= UM()->fields()->new_row_output( $row_id, $row_array );
+                    $output .= UM()->fields()->new_row_output( $row_id, $row_array );
 
-					$sub_rows = ( isset( $row_array['sub_rows'] ) ) ? $row_array['sub_rows'] : 1;
-					for ( $c = 0; $c < $sub_rows; $c++ ) {
+                    $sub_rows = ( isset( $row_array['sub_rows'] ) ) ? $row_array['sub_rows'] : 1;
+                    for ( $c = 0; $c < $sub_rows; $c++ ) {
 
-						// cols
-						$cols = ( isset( $row_array['cols'] ) ) ? $row_array['cols'] : 1;
-						if ( strstr( $cols, ':' ) ) {
-							$col_split = explode( ':', $cols );
-						} else {
-							$col_split = array( $cols );
-						}
-						$cols_num = $col_split[ $c ];
+                        // cols
+                        $cols = ( isset( $row_array['cols'] ) ) ? $row_array['cols'] : 1;
+                        if ( strstr( $cols, ':' ) ) {
+                            $col_split = explode( ':', $cols );
+                        } else {
+                            $col_split = array( $cols );
+                        }
+                        $cols_num = $col_split[ $c ];
 
-						// sub row fields
-						$subrow_fields = null;
-						$subrow_fields = UM()->fields()->get_fields_in_subrow( $row_fields, $c );
+                        // sub row fields
+                        $subrow_fields = null;
+                        $subrow_fields = UM()->fields()->get_fields_in_subrow( $row_fields, $c );
 
-						if ( is_array( $subrow_fields ) ) {
+                        if ( is_array( $subrow_fields ) ) {
 
-							if ( isset( $subrow_fields['form_id'] ) ) {
-								unset( $subrow_fields['form_id'] );
-							}
+                            if ( isset( $subrow_fields['form_id'] ) ) {
+                                unset( $subrow_fields['form_id'] );
+                            }
 
-							$subrow_fields = UM()->fields()->array_sort_by_column( $subrow_fields, 'position' );
+                            $subrow_fields = UM()->fields()->array_sort_by_column( $subrow_fields, 'position' );
 
-							if ( $cols_num == 1 ) {
+                            if ( $cols_num == 1 ) {
 
-								$col1_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 1 );
-								if ( $col1_fields ) {
-									foreach ( $col1_fields as $key => $data ) {
-										$output .= um_user_submited_display( $key, $data['title'] );
-									}
-								}
+                                $col1_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 1 );
+                                if ( $col1_fields ) {
+                                    foreach ( $col1_fields as $key => $data ) {
+                                        $output .= um_user_submited_display( $key, $data['title'] );
+                                    }
+                                }
 
-							} elseif ( $cols_num == 2 ) {
+                            } elseif ( $cols_num == 2 ) {
 
-								$col1_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 1 );
-								if ( $col1_fields ) {
-									foreach ( $col1_fields as $key => $data ) {
-										$output .= um_user_submited_display( $key, $data['title'] );
-									}
-								}
+                                $col1_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 1 );
+                                if ( $col1_fields ) {
+                                    foreach ( $col1_fields as $key => $data ) {
+                                        $output .= um_user_submited_display( $key, $data['title'] );
+                                    }
+                                }
 
-								$col2_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 2 );
-								if ( $col2_fields ) {
-									foreach ( $col2_fields as $key => $data ) {
-										$output .= um_user_submited_display( $key, $data['title'] );
-									}
-								}
+                                $col2_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 2 );
+                                if ( $col2_fields ) {
+                                    foreach ( $col2_fields as $key => $data ) {
+                                        $output .= um_user_submited_display( $key, $data['title'] );
+                                    }
+                                }
 
-							} else {
+                            } else {
 
-								$col1_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 1 );
-								if ( $col1_fields ) {
-									foreach ( $col1_fields as $key => $data ) {
-										$output .= um_user_submited_display( $key, $data['title'] );
-									}
-								}
+                                $col1_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 1 );
+                                if ( $col1_fields ) {
+                                    foreach ( $col1_fields as $key => $data ) {
+                                        $output .= um_user_submited_display( $key, $data['title'] );
+                                    }
+                                }
 
-								$col2_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 2 );
-								if ( $col2_fields ) {
-									foreach ( $col2_fields as $key => $data ) {
-										$output .= um_user_submited_display( $key, $data['title'] );
-									}
-								}
+                                $col2_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 2 );
+                                if ( $col2_fields ) {
+                                    foreach ( $col2_fields as $key => $data ) {
+                                        $output .= um_user_submited_display( $key, $data['title'] );
+                                    }
+                                }
 
-								$col3_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 3 );
-								if ( $col3_fields ) {
-									foreach ( $col3_fields as $key => $data ) {
-										$output .= um_user_submited_display( $key, $data['title'] );
-									}
-								}
+                                $col3_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 3 );
+                                if ( $col3_fields ) {
+                                    foreach ( $col3_fields as $key => $data ) {
+                                        $output .= um_user_submited_display( $key, $data['title'] );
+                                    }
+                                }
 
-							}
+                            }
 
-						}
+                        }
 
-					}
+                    }
 
-				}
-
-
-			} // endfor
-
-		}
-	}
+                }
 
 
-	if ( $style ) {
-		$output .= '</div>';
-	}
+            } // endfor
+
+        }
+    }
 
 
-	return $output;
+    if ( $style ) {
+        $output .= '</div>';
+    }
+
+
+    return $output;
 
 }
 
@@ -834,74 +834,74 @@ function um_user_submitted_registration_formatted( $style = false ) {
  * @param  boolean $style
  * @return string
  *
- * @since  2.1.4 
+ * @since  2.1.4
  */
 function um_user_submited_display( $k, $title, $data = array(), $style = true ) {
-	$output = '';
+    $output = '';
 
-	if ( 'form_id' == $k && isset( $data['form_id'] ) && ! empty( $data['form_id'] ) ) {
-		$v = sprintf( __( '%s - Form ID#: %s', 'ultimate-member' ), get_the_title( $data['form_id'] ), $data['form_id'] );
-	} else {
-		$v = um_user( $k );
-	}
+    if ( 'form_id' == $k && isset( $data['form_id'] ) && ! empty( $data['form_id'] ) ) {
+        $v = sprintf( __( '%s - Form ID#: %s', 'ultimate-member' ), get_the_title( $data['form_id'] ), $data['form_id'] );
+    } else {
+        $v = um_user( $k );
+    }
 
-	if ( strstr( $k, 'user_pass' ) || in_array( $k, array( 'g-recaptcha-response', 'request', '_wpnonce', '_wp_http_referer' ) ) ) {
-		return '';
-	}
+    if ( strstr( $k, 'user_pass' ) || in_array( $k, array( 'g-recaptcha-response', 'request', '_wpnonce', '_wp_http_referer' ) ) ) {
+        return '';
+    }
 
-	$fields_without_metakey = UM()->builtin()->get_fields_without_metakey();
-	$type = UM()->fields()->get_field_type( $k );
-	if ( in_array( $type, $fields_without_metakey ) ) {
-		return '';
-	}
+    $fields_without_metakey = UM()->builtin()->get_fields_without_metakey();
+    $type = UM()->fields()->get_field_type( $k );
+    if ( in_array( $type, $fields_without_metakey ) ) {
+        return '';
+    }
 
-	if ( ! $v ) {
-		if ( $style ) {
-			return "<p><label>$title: </label><span>" . __( '(empty)', 'ultimate-member' ) ."</span></p>";
-		} else {
-			return '';
-		}
-	}
+    if ( ! $v ) {
+        if ( $style ) {
+            return "<p><label>$title: </label><span>" . __( '(empty)', 'ultimate-member' ) ."</span></p>";
+        } else {
+            return '';
+        }
+    }
 
-	if ( $type == 'image' || $type == 'file' ) {
-		$file = basename( $v );
+    if ( $type == 'image' || $type == 'file' ) {
+        $file = basename( $v );
 
-		$filedata = get_user_meta( um_user( 'ID' ), $k . "_metadata", true );
+        $filedata = get_user_meta( um_user( 'ID' ), $k . "_metadata", true );
 
-		$baseurl = UM()->uploader()->get_upload_base_url();
-		if ( ! file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . $file ) ) {
-			if ( is_multisite() ) {
-				//multisite fix for old customers
-				$baseurl = str_replace( '/sites/' . get_current_blog_id() . '/', '/', $baseurl );
-			}
-		}
+        $baseurl = UM()->uploader()->get_upload_base_url();
+        if ( ! file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . $file ) ) {
+            if ( is_multisite() ) {
+                //multisite fix for old customers
+                $baseurl = str_replace( '/sites/' . get_current_blog_id() . '/', '/', $baseurl );
+            }
+        }
 
-		if ( ! empty( $filedata['original_name'] ) ) {
-			$v = '<a href="' . esc_attr( $baseurl . um_user( 'ID' ) . '/' . $file ) . '">' . esc_html( $filedata['original_name'] ) . '</a>';
-		} else {
-			$v = $baseurl . um_user( 'ID' ) . '/' . $file;
-		}
-	}
+        if ( ! empty( $filedata['original_name'] ) ) {
+            $v = '<a href="' . esc_attr( $baseurl . um_user( 'ID' ) . '/' . $file ) . '">' . esc_html( $filedata['original_name'] ) . '</a>';
+        } else {
+            $v = $baseurl . um_user( 'ID' ) . '/' . $file;
+        }
+    }
 
-	if ( is_array( $v ) ) {
-		$v = implode( ',', $v );
-	}
+    if ( is_array( $v ) ) {
+        $v = implode( ',', $v );
+    }
 
-	if ( $k == 'timestamp' ) {
-		$k = __( 'date submitted', 'ultimate-member' );
-		$v = date( "d M Y H:i", $v );
-	}
+    if ( $k == 'timestamp' ) {
+        $k = __( 'date submitted', 'ultimate-member' );
+        $v = date( "d M Y H:i", $v );
+    }
 
-	if ( $style ) {
-		if ( ! $v ) {
-			$v = __( '(empty)', 'ultimate-member' );
-		}
-		$output .= "<p><label>$title: </label><span>$v</span></p>";
-	} else {
-		$output .= "$title: $v" . "<br />";
-	}
+    if ( $style ) {
+        if ( ! $v ) {
+            $v = __( '(empty)', 'ultimate-member' );
+        }
+        $output .= "<p><label>$title: </label><span>$v</span></p>";
+    } else {
+        $output .= "$title: $v" . "<br />";
+    }
 
-	return $output;
+    return $output;
 }
 
 
@@ -914,19 +914,19 @@ function um_user_submited_display( $k, $title, $data = array(), $style = true ) 
  * @return string
  */
 function um_filtered_social_link( $key, $match ) {
-	$value = um_profile( $key );
-	$submatch = str_replace( 'https://', '', $match );
-	$submatch = str_replace( 'http://', '', $submatch );
-	if ( strstr( $value, $submatch ) ) {
-		$value = 'https://' . $value;
-	} elseif ( strpos( $value, 'http' ) !== 0 ) {
-		$value = $match . $value;
-	}
-	$value = str_replace( 'https://https://', 'https://', $value );
-	$value = str_replace( 'http://https://', 'https://', $value );
-	$value = str_replace( 'https://http://', 'https://', $value );
+    $value = um_profile( $key );
+    $submatch = str_replace( 'https://', '', $match );
+    $submatch = str_replace( 'http://', '', $submatch );
+    if ( strstr( $value, $submatch ) ) {
+        $value = 'https://' . $value;
+    } elseif ( strpos( $value, 'http' ) !== 0 ) {
+        $value = $match . $value;
+    }
+    $value = str_replace( 'https://https://', 'https://', $value );
+    $value = str_replace( 'http://https://', 'https://', $value );
+    $value = str_replace( 'https://http://', 'https://', $value );
 
-	return $value;
+    return $value;
 }
 
 
@@ -938,88 +938,88 @@ function um_filtered_social_link( $key, $match ) {
  * @return mixed|string|void
  */
 function um_filtered_value( $key, $data = false ) {
-	$value = um_user( $key );
-	if ( is_array( $value ) ) {
-		$value = add_magic_quotes( $value );
-	}
+    $value = um_user( $key );
+    if ( is_array( $value ) ) {
+        $value = add_magic_quotes( $value );
+    }
 
-	if ( ! $data ) {
-		$data = UM()->builtin()->get_specific_field( $key );
-	}
+    if ( ! $data ) {
+        $data = UM()->builtin()->get_specific_field( $key );
+    }
 
-	$type = ( isset( $data['type'] ) ) ? $data['type'] : '';
+    $type = ( isset( $data['type'] ) ) ? $data['type'] : '';
 
-	/**
-	 * UM hook
-	 *
-	 * @type filter
-	 * @title um_profile_field_filter_hook__
-	 * @description Change or filter field value
-	 * @input_vars
-	 * [{"var":"$value","type":"string","desc":"Field Value"},
-	 * {"var":"$data","type":"array","desc":"Field Data"},
-	 * {"var":"$type","type":"string","desc":"Field Type"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_profile_field_filter_hook__', 'function_name', 10, 3 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_profile_field_filter_hook__', 'my_profile_field', 10, 3 );
-	 * function my_profile_field( $value, $data, $type ) {
-	 *     // your code here
-	 *     return $value;
-	 * }
-	 * ?>
-	 */
-	$value = apply_filters( 'um_profile_field_filter_hook__', $value, $data, $type );
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_profile_field_filter_hook__
+     * @description Change or filter field value
+     * @input_vars
+     * [{"var":"$value","type":"string","desc":"Field Value"},
+     * {"var":"$data","type":"array","desc":"Field Data"},
+     * {"var":"$type","type":"string","desc":"Field Type"}]
+     * @change_log
+     * ["Since: 2.0"]
+     * @usage add_filter( 'um_profile_field_filter_hook__', 'function_name', 10, 3 );
+     * @example
+     * <?php
+     * add_filter( 'um_profile_field_filter_hook__', 'my_profile_field', 10, 3 );
+     * function my_profile_field( $value, $data, $type ) {
+     *     // your code here
+     *     return $value;
+     * }
+     * ?>
+     */
+    $value = apply_filters( 'um_profile_field_filter_hook__', $value, $data, $type );
 
-	/**
-	 * UM hook
-	 *
-	 * @type filter
-	 * @title um_profile_field_filter_hook__{$key}
-	 * @description Change or filter field value by field key ($key)
-	 * @input_vars
-	 * [{"var":"$value","type":"string","desc":"Field Value"},
-	 * {"var":"$data","type":"array","desc":"Field Data"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_profile_field_filter_hook__{$key}', 'function_name', 10, 2 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_profile_field_filter_hook__{$key}', 'my_profile_field', 10, 2 );
-	 * function my_profile_field( $value, $data ) {
-	 *     // your code here
-	 *     return $value;
-	 * }
-	 * ?>
-	 */
-	$value = apply_filters( "um_profile_field_filter_hook__{$key}", $value, $data );
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_profile_field_filter_hook__{$key}
+     * @description Change or filter field value by field key ($key)
+     * @input_vars
+     * [{"var":"$value","type":"string","desc":"Field Value"},
+     * {"var":"$data","type":"array","desc":"Field Data"}]
+     * @change_log
+     * ["Since: 2.0"]
+     * @usage add_filter( 'um_profile_field_filter_hook__{$key}', 'function_name', 10, 2 );
+     * @example
+     * <?php
+     * add_filter( 'um_profile_field_filter_hook__{$key}', 'my_profile_field', 10, 2 );
+     * function my_profile_field( $value, $data ) {
+     *     // your code here
+     *     return $value;
+     * }
+     * ?>
+     */
+    $value = apply_filters( "um_profile_field_filter_hook__{$key}", $value, $data );
 
-	/**
-	 * UM hook
-	 *
-	 * @type filter
-	 * @title um_profile_field_filter_hook__{$type}
-	 * @description Change or filter field value by field type ($type)
-	 * @input_vars
-	 * [{"var":"$value","type":"string","desc":"Field Value"},
-	 * {"var":"$data","type":"array","desc":"Field Data"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_profile_field_filter_hook__{$type}', 'function_name', 10, 2 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_profile_field_filter_hook__{$type}', 'my_profile_field', 10, 2 );
-	 * function my_profile_field( $value, $data ) {
-	 *     // your code here
-	 *     return $value;
-	 * }
-	 * ?>
-	 */
-	$value = apply_filters( "um_profile_field_filter_hook__{$type}", $value, $data );
-	$value = UM()->shortcodes()->emotize( $value );
-	return $value;
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_profile_field_filter_hook__{$type}
+     * @description Change or filter field value by field type ($type)
+     * @input_vars
+     * [{"var":"$value","type":"string","desc":"Field Value"},
+     * {"var":"$data","type":"array","desc":"Field Data"}]
+     * @change_log
+     * ["Since: 2.0"]
+     * @usage add_filter( 'um_profile_field_filter_hook__{$type}', 'function_name', 10, 2 );
+     * @example
+     * <?php
+     * add_filter( 'um_profile_field_filter_hook__{$type}', 'my_profile_field', 10, 2 );
+     * function my_profile_field( $value, $data ) {
+     *     // your code here
+     *     return $value;
+     * }
+     * ?>
+     */
+    $value = apply_filters( "um_profile_field_filter_hook__{$type}", $value, $data );
+    $value = UM()->shortcodes()->emotize( $value );
+    return $value;
 }
 
 
@@ -1029,15 +1029,15 @@ function um_filtered_value( $key, $data = false ) {
  * @return int
  */
 function um_profile_id() {
-	$requested_user = um_get_requested_user();
+    $requested_user = um_get_requested_user();
 
-	if ( $requested_user ) {
-		return um_get_requested_user();
-	} elseif ( is_user_logged_in() && get_current_user_id() ) {
-		return get_current_user_id();
-	}
+    if ( $requested_user ) {
+        return um_get_requested_user();
+    } elseif ( is_user_logged_in() && get_current_user_id() ) {
+        return get_current_user_id();
+    }
 
-	return 0;
+    return 0;
 }
 
 
@@ -1049,34 +1049,34 @@ function um_profile_id() {
  * @return bool|string
  */
 function um_is_temp_upload( $url ) {
-	if ( is_string( $url ) ) {
-		$url = trim( $url );
-	}
+    if ( is_string( $url ) ) {
+        $url = trim( $url );
+    }
 
-	if ( filter_var( $url, FILTER_VALIDATE_URL ) === false ) {
-		$url = realpath( $url );
-	}
+    if ( filter_var( $url, FILTER_VALIDATE_URL ) === false ) {
+        $url = realpath( $url );
+    }
 
-	if ( ! $url ) {
-		return false;
-	}
+    if ( ! $url ) {
+        return false;
+    }
 
-	$url = explode( '/ultimatemember/temp/', $url );
-	if ( isset( $url[1] ) ) {
+    $url = explode( '/ultimatemember/temp/', $url );
+    if ( isset( $url[1] ) ) {
 
-		if ( strstr( $url[1], '../' ) || strstr( $url[1], '%' ) ) {
-			return false;
-		}
+        if ( strstr( $url[1], '../' ) || strstr( $url[1], '%' ) ) {
+            return false;
+        }
 
-		$src = UM()->files()->upload_temp . $url[1];
-		if ( ! file_exists( $src ) ) {
-			return false;
-		}
+        $src = UM()->files()->upload_temp . $url[1];
+        if ( ! file_exists( $src ) ) {
+            return false;
+        }
 
-		return $src;
-	}
+        return $src;
+    }
 
-	return false;
+    return false;
 }
 
 
@@ -1088,17 +1088,17 @@ function um_is_temp_upload( $url ) {
  * @return bool|string
  */
 function um_is_temp_image( $url ) {
-	$url = explode( '/ultimatemember/temp/', $url );
-	if (isset( $url[1] )) {
-		$src = UM()->files()->upload_temp . $url[1];
-		if (!file_exists( $src ))
-			return false;
-		list( $width, $height, $type, $attr ) = @getimagesize( $src );
-		if (isset( $width ) && isset( $height ))
-			return $src;
-	}
+    $url = explode( '/ultimatemember/temp/', $url );
+    if (isset( $url[1] )) {
+        $src = UM()->files()->upload_temp . $url[1];
+        if (!file_exists( $src ))
+            return false;
+        list( $width, $height, $type, $attr ) = @getimagesize( $src );
+        if (isset( $width ) && isset( $height ))
+            return $src;
+    }
 
-	return false;
+    return false;
 }
 
 
@@ -1111,41 +1111,41 @@ function um_is_temp_image( $url ) {
  */
 function um_is_file_owner( $url, $user_id = null, $image_path = false ) {
 
-	if ( strpos( $url, UM()->uploader()->get_upload_base_url() . $user_id . '/' ) !== false && is_user_logged_in() ) {
-		$user_basedir = UM()->uploader()->get_upload_user_base_dir( $user_id );
-	} else {
-		$user_basedir = UM()->uploader()->get_upload_user_base_dir( 'temp' );
-	}
+    if ( strpos( $url, UM()->uploader()->get_upload_base_url() . $user_id . '/' ) !== false && is_user_logged_in() ) {
+        $user_basedir = UM()->uploader()->get_upload_user_base_dir( $user_id );
+    } else {
+        $user_basedir = UM()->uploader()->get_upload_user_base_dir( 'temp' );
+    }
 
-	$filename = wp_basename( parse_url( $url, PHP_URL_PATH ) );
+    $filename = wp_basename( parse_url( $url, PHP_URL_PATH ) );
 
-	$file = $user_basedir . DIRECTORY_SEPARATOR . $filename;
-	if ( file_exists( $file ) ) {
-		if ( $image_path ) {
-			return $file;
-		}
+    $file = $user_basedir . DIRECTORY_SEPARATOR . $filename;
+    if ( file_exists( $file ) ) {
+        if ( $image_path ) {
+            return $file;
+        }
 
-		return true;
-	}
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
 
 /**
  * Check if file is temporary
- * @param  string $filename 
- * @return bool       
+ * @param  string $filename
+ * @return bool
  */
 function um_is_temp_file( $filename ) {
-	$user_basedir = UM()->uploader()->get_upload_user_base_dir( 'temp' );
+    $user_basedir = UM()->uploader()->get_upload_user_base_dir( 'temp' );
 
-	$file = $user_basedir . '/' . $filename;
+    $file = $user_basedir . '/' . $filename;
 
-	if ( file_exists( $file ) ) {
-		return true;
-	}
-	return false;
+    if ( file_exists( $file ) ) {
+        return true;
+    }
+    return false;
 }
 
 
@@ -1157,12 +1157,12 @@ function um_is_temp_file( $filename ) {
  * @return mixed|string
  */
 function um_user_last_login_timestamp( $user_id ) {
-	$value = get_user_meta( $user_id, '_um_last_login', true );
-	if ( $value ) {
-		return $value;
-	}
+    $value = get_user_meta( $user_id, '_um_last_login', true );
+    if ( $value ) {
+        return $value;
+    }
 
-	return '';
+    return '';
 }
 
 
@@ -1174,8 +1174,8 @@ function um_user_last_login_timestamp( $user_id ) {
  * @return string
  */
 function um_user_last_login( $user_id ) {
-	$value = get_user_meta( $user_id, '_um_last_login', true );
-	return ! empty( $value ) ? UM()->datetime()->time_diff( $value, current_time( 'timestamp' ) ) : '';
+    $value = get_user_meta( $user_id, '_um_last_login', true );
+    return ! empty( $value ) ? UM()->datetime()->time_diff( $value, current_time( 'timestamp' ) ) : '';
 }
 
 
@@ -1188,38 +1188,38 @@ function um_user_last_login( $user_id ) {
  * @return bool|false|mixed|string|void
  */
 function um_get_core_page( $slug, $updated = false ) {
-	$url = '';
+    $url = '';
 
-	if ( isset( UM()->config()->permalinks[ $slug ] ) ) {
-		$url = get_permalink( UM()->config()->permalinks[ $slug ] );
-		if ( $updated ) {
-			$url = add_query_arg( 'updated', esc_attr( $updated ), $url );
-		}
-	}
+    if ( isset( UM()->config()->permalinks[ $slug ] ) ) {
+        $url = get_permalink( UM()->config()->permalinks[ $slug ] );
+        if ( $updated ) {
+            $url = add_query_arg( 'updated', esc_attr( $updated ), $url );
+        }
+    }
 
-	/**
-	 * UM hook
-	 *
-	 * @type filter
-	 * @title um_get_core_page_filter
-	 * @description Change UM core page URL
-	 * @input_vars
-	 * [{"var":"$url","type":"string","desc":"UM Page URL"},
-	 * {"var":"$slug","type":"string","desc":"UM Page slug"},
-	 * {"var":"$updated","type":"bool","desc":"Additional parameter"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_get_core_page_filter', 'function_name', 10, 3 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_get_core_page_filter', 'my_core_page_url', 10, 3 );
-	 * function my_core_page_url( $url, $slug, $updated ) {
-	 *     // your code here
-	 *     return $url;
-	 * }
-	 * ?>
-	 */
-	return apply_filters( 'um_get_core_page_filter', $url, $slug, $updated );
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_get_core_page_filter
+     * @description Change UM core page URL
+     * @input_vars
+     * [{"var":"$url","type":"string","desc":"UM Page URL"},
+     * {"var":"$slug","type":"string","desc":"UM Page slug"},
+     * {"var":"$updated","type":"bool","desc":"Additional parameter"}]
+     * @change_log
+     * ["Since: 2.0"]
+     * @usage add_filter( 'um_get_core_page_filter', 'function_name', 10, 3 );
+     * @example
+     * <?php
+     * add_filter( 'um_get_core_page_filter', 'my_core_page_url', 10, 3 );
+     * function my_core_page_url( $url, $slug, $updated ) {
+     *     // your code here
+     *     return $url;
+     * }
+     * ?>
+     */
+    return apply_filters( 'um_get_core_page_filter', $url, $slug, $updated );
 }
 
 
@@ -1234,36 +1234,59 @@ function um_get_core_page( $slug, $updated = false ) {
  * @return bool
  */
 function um_is_core_page( $page ) {
-	global $post;
+    global $post;
 
-	if ( empty( $post ) ) {
-		return false;
-	}
+    if ( empty( $post ) ) {
+        return false;
+    }
 
-	if ( isset( $post->ID ) && isset( UM()->config()->permalinks[ $page ] ) && $post->ID == UM()->config()->permalinks[ $page ] ) {
-		return true;
-	}
+    if ( isset( $post->ID ) && isset( UM()->config()->permalinks[ $page ] ) && $post->ID == UM()->config()->permalinks[ $page ] ) {
+        return true;
+    }
 
-	if ( isset( $post->ID ) && get_post_meta( $post->ID, '_um_wpml_' . $page, true ) == 1 ) {
-		return true;
-	}
+    if ( isset( $post->ID ) && get_post_meta( $post->ID, '_um_wpml_' . $page, true ) == 1 ) {
+        return true;
+    }
 
-	if ( UM()->external_integrations()->is_wpml_active() ) {
-		global $sitepress;
-		if ( isset( UM()->config()->permalinks[ $page ] ) && UM()->config()->permalinks[ $page ] == wpml_object_id_filter( $post->ID, 'page', true, $sitepress->get_default_language() ) ) {
-			return true;
-		}
-	}
+    if ( UM()->external_integrations()->is_wpml_active() ) {
+        global $sitepress;
+        if ( isset( UM()->config()->permalinks[ $page ] ) && UM()->config()->permalinks[ $page ] == wpml_object_id_filter( $post->ID, 'page', true, $sitepress->get_default_language() ) ) {
+            return true;
+        }
+    }
 
-	if ( isset( $post->ID ) ) {
-		$_icl_lang_duplicate_of = get_post_meta( $post->ID, '_icl_lang_duplicate_of', true );
+    if ( isset( $post->ID ) ) {
+        $_icl_lang_duplicate_of = get_post_meta( $post->ID, '_icl_lang_duplicate_of', true );
 
-		if ( isset( UM()->config()->permalinks[ $page ] ) && ( ( $_icl_lang_duplicate_of == UM()->config()->permalinks[ $page ] && !empty( $_icl_lang_duplicate_of ) ) || UM()->config()->permalinks[ $page ] == $post->ID ) ) {
-			return true;
-		}
-	}
+        if ( isset( UM()->config()->permalinks[ $page ] ) && ( ( $_icl_lang_duplicate_of == UM()->config()->permalinks[ $page ] && !empty( $_icl_lang_duplicate_of ) ) || UM()->config()->permalinks[ $page ] == $post->ID ) ) {
+            return true;
+        }
+    }
 
-	return false;
+
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_is_core_page_filter
+     * @description Change UM is core page returned value
+     * @input_vars
+     * [{"var":"$is_core_page","type":"bool","desc":"Is core page slug a core page"},
+     * {"var":"$page","type":"string","desc":"UM core page slug"},
+     * {"var":"$post","type":"array","desc":"Post data"}]
+     * @change_log
+     * ["Personal addition - PR"]
+     * @usage add_filter( 'um_is_core_page_filter', 'function_name', 10, 3 );
+     * @example
+     * <?php
+     * add_filter( 'um_is_core_page_filter', 'my_is_core_page_filter', 10, 3 );
+     * function my_is_core_page_filter( $is_core_page, $page, $post ) {
+     *     // your code here
+     *     return $is_core_page;
+     * }
+     * ?>
+     */
+    return apply_filters( 'um_is_core_page_filter', false, $page, $post );
 }
 
 
@@ -1274,22 +1297,22 @@ function um_is_core_page( $page ) {
  * @return bool
  */
 function um_is_core_post( $post, $core_page ) {
-	if ( isset( $post->ID ) && isset( UM()->config()->permalinks[ $core_page ] ) && $post->ID == UM()->config()->permalinks[ $core_page ] ) {
-		return true;
-	}
-	if ( isset( $post->ID ) && get_post_meta( $post->ID, '_um_wpml_' . $core_page, true ) == 1 ) {
-		return true;
-	}
+    if ( isset( $post->ID ) && isset( UM()->config()->permalinks[ $core_page ] ) && $post->ID == UM()->config()->permalinks[ $core_page ] ) {
+        return true;
+    }
+    if ( isset( $post->ID ) && get_post_meta( $post->ID, '_um_wpml_' . $core_page, true ) == 1 ) {
+        return true;
+    }
 
-	if ( isset( $post->ID ) ) {
-		$_icl_lang_duplicate_of = get_post_meta( $post->ID, '_icl_lang_duplicate_of', true );
+    if ( isset( $post->ID ) ) {
+        $_icl_lang_duplicate_of = get_post_meta( $post->ID, '_icl_lang_duplicate_of', true );
 
-		if ( isset( UM()->config()->permalinks[ $core_page ] ) && ( ( $_icl_lang_duplicate_of == UM()->config()->permalinks[ $core_page ] && ! empty( $_icl_lang_duplicate_of ) ) || UM()->config()->permalinks[ $core_page ] == $post->ID ) ) {
-			return true;
-		}
-	}
+        if ( isset( UM()->config()->permalinks[ $core_page ] ) && ( ( $_icl_lang_duplicate_of == UM()->config()->permalinks[ $core_page ] && ! empty( $_icl_lang_duplicate_of ) ) || UM()->config()->permalinks[ $core_page ] == $post->ID ) ) {
+            return true;
+        }
+    }
 
-	return false;
+    return false;
 }
 
 
@@ -1302,23 +1325,23 @@ function um_is_core_post( $post, $core_page ) {
  */
 function um_styling_defaults( $mode ) {
 
-	$new_arr = array();
-	$core_form_meta_all = UM()->config()->core_form_meta_all;
-	$core_global_meta_all = UM()->config()->core_global_meta_all;
+    $new_arr = array();
+    $core_form_meta_all = UM()->config()->core_form_meta_all;
+    $core_global_meta_all = UM()->config()->core_global_meta_all;
 
-	foreach ( $core_form_meta_all as $k => $v ) {
-		$s = str_replace( $mode . '_', '', $k );
-		if (strstr( $k, '_um_' . $mode . '_' ) && !in_array( $s, $core_global_meta_all )) {
-			$a = str_replace( '_um_' . $mode . '_', '', $k );
-			$b = str_replace( '_um_', '', $k );
-			$new_arr[$a] = UM()->options()->get( $b );
-		} else if (in_array( $k, $core_global_meta_all )) {
-			$a = str_replace( '_um_', '', $k );
-			$new_arr[$a] = UM()->options()->get( $a );
-		}
-	}
+    foreach ( $core_form_meta_all as $k => $v ) {
+        $s = str_replace( $mode . '_', '', $k );
+        if (strstr( $k, '_um_' . $mode . '_' ) && !in_array( $s, $core_global_meta_all )) {
+            $a = str_replace( '_um_' . $mode . '_', '', $k );
+            $b = str_replace( '_um_', '', $k );
+            $new_arr[$a] = UM()->options()->get( $b );
+        } else if (in_array( $k, $core_global_meta_all )) {
+            $a = str_replace( '_um_', '', $k );
+            $new_arr[$a] = UM()->options()->get( $a );
+        }
+    }
 
-	return $new_arr;
+    return $new_arr;
 }
 
 
@@ -1330,9 +1353,9 @@ function um_styling_defaults( $mode ) {
  * @return string
  */
 function um_get_metadefault( $id ) {
-	$core_form_meta_all = UM()->config()->core_form_meta_all;
+    $core_form_meta_all = UM()->config()->core_form_meta_all;
 
-	return isset( $core_form_meta_all[ '_um_' . $id ] ) ? $core_form_meta_all[ '_um_' . $id ] : '';
+    return isset( $core_form_meta_all[ '_um_' . $id ] ) ? $core_form_meta_all[ '_um_' . $id ] : '';
 }
 
 
@@ -1342,11 +1365,11 @@ function um_get_metadefault( $id ) {
  * @return bool
  */
 function um_submitting_account_page() {
-	if ( isset( $_POST['_um_account'] ) && $_POST['_um_account'] == 1 && is_user_logged_in() ) {
-		return true;
-	}
+    if ( isset( $_POST['_um_account'] ) && $_POST['_um_account'] == 1 && is_user_logged_in() ) {
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
 
@@ -1358,11 +1381,11 @@ function um_submitting_account_page() {
  * @return string
  */
 function um_get_display_name( $user_id ) {
-	um_fetch_user( $user_id );
-	$name = um_user( 'display_name' );
-	um_reset_user();
+    um_fetch_user( $user_id );
+    $name = um_user( 'display_name' );
+    um_reset_user();
 
-	return $name;
+    return $name;
 }
 
 
@@ -1381,7 +1404,7 @@ function um_get_display_name( $user_id ) {
  * <?php um_reset_user_clean(); ?>
  */
 function um_reset_user_clean() {
-	UM()->user()->reset( true );
+    UM()->user()->reset( true );
 }
 
 
@@ -1400,7 +1423,7 @@ function um_reset_user_clean() {
  * <?php um_reset_user(); ?>
  */
 function um_reset_user() {
-	UM()->user()->reset();
+    UM()->user()->reset();
 }
 
 
@@ -1410,7 +1433,7 @@ function um_reset_user() {
  * @return mixed
  */
 function um_queried_user() {
-	return get_query_var( 'um_user' );
+    return get_query_var( 'um_user' );
 }
 
 
@@ -1420,7 +1443,7 @@ function um_queried_user() {
  * @param $user_id
  */
 function um_set_requested_user( $user_id ) {
-	UM()->user()->target_id = $user_id;
+    UM()->user()->target_id = $user_id;
 }
 
 
@@ -1430,11 +1453,11 @@ function um_set_requested_user( $user_id ) {
  * @return bool|null
  */
 function um_get_requested_user() {
-	if ( ! empty( UM()->user()->target_id ) ) {
-		return UM()->user()->target_id;
-	}
+    if ( ! empty( UM()->user()->target_id ) ) {
+        return UM()->user()->target_id;
+    }
 
-	return false;
+    return false;
 }
 
 
@@ -1447,35 +1470,35 @@ function um_get_requested_user() {
  */
 function um_edit_my_profile_cancel_uri( $url = '' ) {
 
-	if ( empty( $url ) ) {
-		$url = remove_query_arg( 'um_action' );
-		$url = remove_query_arg( 'profiletab', $url );
-		$url = add_query_arg( 'profiletab', 'main', $url );
-	}
+    if ( empty( $url ) ) {
+        $url = remove_query_arg( 'um_action' );
+        $url = remove_query_arg( 'profiletab', $url );
+        $url = add_query_arg( 'profiletab', 'main', $url );
+    }
 
-	/**
-	 * UM hook
-	 *
-	 * @type filter
-	 * @title um_edit_profile_cancel_uri
-	 * @description Change Edit Profile Cancel URL
-	 * @input_vars
-	 * [{"var":"$url","type":"string","desc":"Cancel URL"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_edit_profile_cancel_uri', 'function_name', 10, 1 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_edit_profile_cancel_uri', 'my_edit_profile_cancel_uri', 10, 1 );
-	 * function my_edit_profile_cancel_uri( $url ) {
-	 *     // your code here
-	 *     return $url;
-	 * }
-	 * ?>
-	 */
-	$url = apply_filters( 'um_edit_profile_cancel_uri', $url );
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_edit_profile_cancel_uri
+     * @description Change Edit Profile Cancel URL
+     * @input_vars
+     * [{"var":"$url","type":"string","desc":"Cancel URL"}]
+     * @change_log
+     * ["Since: 2.0"]
+     * @usage add_filter( 'um_edit_profile_cancel_uri', 'function_name', 10, 1 );
+     * @example
+     * <?php
+     * add_filter( 'um_edit_profile_cancel_uri', 'my_edit_profile_cancel_uri', 10, 1 );
+     * function my_edit_profile_cancel_uri( $url ) {
+     *     // your code here
+     *     return $url;
+     * }
+     * ?>
+     */
+    $url = apply_filters( 'um_edit_profile_cancel_uri', $url );
 
-	return $url;
+    return $url;
 }
 
 
@@ -1485,11 +1508,11 @@ function um_edit_my_profile_cancel_uri( $url = '' ) {
  * @return bool
  */
 function um_is_on_edit_profile() {
-	if ( isset( $_REQUEST['um_action'] ) && $_REQUEST['um_action'] == 'edit' ) {
-		return true;
-	}
+    if ( isset( $_REQUEST['um_action'] ) && $_REQUEST['um_action'] == 'edit' ) {
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
 
@@ -1501,68 +1524,68 @@ function um_is_on_edit_profile() {
  * @return bool
  */
 function um_can_view_field( $data ) {
-	$can_view = true;
+    $can_view = true;
 
-	if ( ! isset( UM()->fields()->set_mode ) ) {
-		UM()->fields()->set_mode = '';
-	}
+    if ( ! isset( UM()->fields()->set_mode ) ) {
+        UM()->fields()->set_mode = '';
+    }
 
-	if ( isset( $data['public'] ) && UM()->fields()->set_mode != 'register' ) {
+    if ( isset( $data['public'] ) && UM()->fields()->set_mode != 'register' ) {
 
-		if ( is_user_logged_in() ) {
-			$previous_user = um_user( 'ID' );
-			um_fetch_user( get_current_user_id() );
+        if ( is_user_logged_in() ) {
+            $previous_user = um_user( 'ID' );
+            um_fetch_user( get_current_user_id() );
 
-			$current_user_roles = um_user( 'roles' );
-			um_fetch_user( $previous_user );
-		}
+            $current_user_roles = um_user( 'roles' );
+            um_fetch_user( $previous_user );
+        }
 
-		switch ( $data['public'] ) {
-			case '1':
-				$can_view = true;
-				break;
-			case '2':
-				if ( ! is_user_logged_in() ) {
-					$can_view = false;
-				}
-				break;
-			case '-1':
-				if ( ! is_user_logged_in() ) {
-					$can_view = false;
-				} else {
-					if ( ! um_is_user_himself() && ! UM()->roles()->um_user_can( 'can_edit_everyone' ) ) {
-						$can_view = false;
-					}
-				}
-				break;
-			case '-2':
-				if ( ! is_user_logged_in() ) {
-					$can_view = false;
-				} else {
-					if ( ! empty( $data['roles'] ) ) {
-						if ( empty( $current_user_roles ) || count( array_intersect( $current_user_roles, $data['roles'] ) ) <= 0 ) {
-							$can_view = false;
-						}
-					}
-				}
-				break;
-			case '-3':
-				if ( ! is_user_logged_in() ) {
-					$can_view = false;
-				} else {
-					if ( ! um_is_user_himself() && ( empty( $current_user_roles ) || ( ! empty( $data['roles'] ) && count( array_intersect( $current_user_roles, $data['roles'] ) ) <= 0 ) ) ) {
-						$can_view = false;
-					}
-				}
-				break;
-			default:
-				$can_view = apply_filters( 'um_can_view_field_custom', $can_view, $data );
-				break;
-		}
+        switch ( $data['public'] ) {
+            case '1':
+                $can_view = true;
+                break;
+            case '2':
+                if ( ! is_user_logged_in() ) {
+                    $can_view = false;
+                }
+                break;
+            case '-1':
+                if ( ! is_user_logged_in() ) {
+                    $can_view = false;
+                } else {
+                    if ( ! um_is_user_himself() && ! UM()->roles()->um_user_can( 'can_edit_everyone' ) ) {
+                        $can_view = false;
+                    }
+                }
+                break;
+            case '-2':
+                if ( ! is_user_logged_in() ) {
+                    $can_view = false;
+                } else {
+                    if ( ! empty( $data['roles'] ) ) {
+                        if ( empty( $current_user_roles ) || count( array_intersect( $current_user_roles, $data['roles'] ) ) <= 0 ) {
+                            $can_view = false;
+                        }
+                    }
+                }
+                break;
+            case '-3':
+                if ( ! is_user_logged_in() ) {
+                    $can_view = false;
+                } else {
+                    if ( ! um_is_user_himself() && ( empty( $current_user_roles ) || ( ! empty( $data['roles'] ) && count( array_intersect( $current_user_roles, $data['roles'] ) ) <= 0 ) ) ) {
+                        $can_view = false;
+                    }
+                }
+                break;
+            default:
+                $can_view = apply_filters( 'um_can_view_field_custom', $can_view, $data );
+                break;
+        }
 
-	}
+    }
 
-	return apply_filters( 'um_can_view_field', $can_view, $data );
+    return apply_filters( 'um_can_view_field', $can_view, $data );
 }
 
 
@@ -1574,41 +1597,41 @@ function um_can_view_field( $data ) {
  * @return bool
  */
 function um_can_view_profile( $user_id ) {
-	if ( UM()->roles()->um_current_user_can( 'edit', $user_id ) ) {
-		return true;
-	}
+    if ( UM()->roles()->um_current_user_can( 'edit', $user_id ) ) {
+        return true;
+    }
 
-	if ( ! is_user_logged_in() ) {
-		return ! UM()->user()->is_private_profile( $user_id );
-	}
+    if ( ! is_user_logged_in() ) {
+        return ! UM()->user()->is_private_profile( $user_id );
+    }
 
-	$temp_id = um_user('ID');
-	um_fetch_user( get_current_user_id() );
+    $temp_id = um_user('ID');
+    um_fetch_user( get_current_user_id() );
 
-	if ( ! um_user( 'can_view_all' ) && $user_id != get_current_user_id() && is_user_logged_in() ) {
-		um_fetch_user( $temp_id );
-		return false;
-	}
+    if ( ! um_user( 'can_view_all' ) && $user_id != get_current_user_id() && is_user_logged_in() ) {
+        um_fetch_user( $temp_id );
+        return false;
+    }
 
-	if ( ! um_user( 'can_access_private_profile' ) && UM()->user()->is_private_profile( $user_id ) ) {
-		um_fetch_user( $temp_id );
-		return false;
-	}
+    if ( ! um_user( 'can_access_private_profile' ) && UM()->user()->is_private_profile( $user_id ) ) {
+        um_fetch_user( $temp_id );
+        return false;
+    }
 
-	if ( um_user( 'can_view_roles' ) && $user_id != get_current_user_id() ) {
-		$can_view_roles = um_user( 'can_view_roles' );
+    if ( um_user( 'can_view_roles' ) && $user_id != get_current_user_id() ) {
+        $can_view_roles = um_user( 'can_view_roles' );
 
-		if ( ! is_array( $can_view_roles ) ) {
-			$can_view_roles = array();
-		}
+        if ( ! is_array( $can_view_roles ) ) {
+            $can_view_roles = array();
+        }
 
-		if ( count( $can_view_roles ) && count( array_intersect( UM()->roles()->get_all_user_roles( $user_id ), $can_view_roles ) ) <= 0 ) {
-			um_fetch_user( $temp_id );
-			return false;
-		}
-	}
-	um_fetch_user( $temp_id );
-	return true;
+        if ( count( $can_view_roles ) && count( array_intersect( UM()->roles()->get_all_user_roles( $user_id ), $can_view_roles ) ) <= 0 ) {
+            um_fetch_user( $temp_id );
+            return false;
+        }
+    }
+    um_fetch_user( $temp_id );
+    return true;
 }
 
 
@@ -1618,10 +1641,10 @@ function um_can_view_profile( $user_id ) {
  * @return bool
  */
 function um_is_user_himself() {
-	if (um_get_requested_user() && um_get_requested_user() != get_current_user_id())
-		return false;
+    if (um_get_requested_user() && um_get_requested_user() != get_current_user_id())
+        return false;
 
-	return true;
+    return true;
 }
 
 /**
@@ -1632,25 +1655,25 @@ function um_is_user_himself() {
  * @return bool
  */
 function um_can_edit_field( $data ) {
-	$can_edit = true;
+    $can_edit = true;
 
-	if ( ! empty( UM()->fields()->editing ) && isset( UM()->fields()->set_mode ) && UM()->fields()->set_mode == 'profile' ) {
-		if ( ! is_user_logged_in() ) {
-			$can_edit = false;
-		} else {
-			if ( ! UM()->roles()->um_user_can( 'can_edit_everyone' ) ) {
-				if ( isset( $data['editable'] ) && $data['editable'] == 0 ) {
-					$can_edit = false;
-				} else {
-					if ( ! um_is_user_himself() ) {
-						$can_edit = false;
-					}
-				}
-			}
-		}
-	}
+    if ( ! empty( UM()->fields()->editing ) && isset( UM()->fields()->set_mode ) && UM()->fields()->set_mode == 'profile' ) {
+        if ( ! is_user_logged_in() ) {
+            $can_edit = false;
+        } else {
+            if ( ! UM()->roles()->um_user_can( 'can_edit_everyone' ) ) {
+                if ( isset( $data['editable'] ) && $data['editable'] == 0 ) {
+                    $can_edit = false;
+                } else {
+                    if ( ! um_is_user_himself() ) {
+                        $can_edit = false;
+                    }
+                }
+            }
+        }
+    }
 
-	return apply_filters( 'um_can_edit_field', $can_edit, $data );
+    return apply_filters( 'um_can_edit_field', $can_edit, $data );
 }
 
 
@@ -1660,10 +1683,10 @@ function um_can_edit_field( $data ) {
  * @return bool
  */
 function um_is_myprofile() {
-	if (get_current_user_id() && get_current_user_id() == um_get_requested_user()) return true;
-	if (!um_get_requested_user() && um_is_core_page( 'user' ) && get_current_user_id()) return true;
+    if (get_current_user_id() && get_current_user_id() == um_get_requested_user()) return true;
+    if (!um_get_requested_user() && um_is_core_page( 'user' ) && get_current_user_id()) return true;
 
-	return false;
+    return false;
 }
 
 
@@ -1673,17 +1696,17 @@ function um_is_myprofile() {
  * @return string
  */
 function um_edit_profile_url() {
-	if ( um_is_core_page( 'user' ) ) {
-		$url = UM()->permalinks()->get_current_url();
-	} else {
-		$url = um_user_profile_url();
-	}
+    if ( um_is_core_page( 'user' ) ) {
+        $url = UM()->permalinks()->get_current_url();
+    } else {
+        $url = um_user_profile_url();
+    }
 
-	$url = remove_query_arg( 'profiletab', $url );
-	$url = remove_query_arg( 'subnav', $url );
-	$url = add_query_arg( 'um_action', 'edit', $url );
+    $url = remove_query_arg( 'profiletab', $url );
+    $url = remove_query_arg( 'subnav', $url );
+    $url = add_query_arg( 'um_action', 'edit', $url );
 
-	return $url;
+    return $url;
 }
 
 
@@ -1693,11 +1716,11 @@ function um_edit_profile_url() {
  * @return bool
  */
 function um_can_edit_my_profile() {
-	if ( ! is_user_logged_in() || ! um_user( 'can_edit_profile' ) ) {
-		return false;
-	}
+    if ( ! is_user_logged_in() || ! um_user( 'can_edit_profile' ) ) {
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
 
@@ -1707,7 +1730,7 @@ function um_can_edit_my_profile() {
  * @return mixed|string|void
  */
 function um_admin_email() {
-	return UM()->options()->get( 'admin_email' );
+    return UM()->options()->get( 'admin_email' );
 }
 
 
@@ -1717,15 +1740,15 @@ function um_admin_email() {
  * @return array
  */
 function um_multi_admin_email() {
-	$emails = UM()->options()->get( 'admin_email' );
+    $emails = UM()->options()->get( 'admin_email' );
 
-	$emails_array = explode( ',', $emails );
-	if ( ! empty( $emails_array ) ) {
-		$emails_array = array_map( 'trim', $emails_array );
-	}
+    $emails_array = explode( ',', $emails );
+    if ( ! empty( $emails_array ) ) {
+        $emails_array = array_map( 'trim', $emails_array );
+    }
 
-	$emails_array = array_unique( $emails_array );
-	return $emails_array;
+    $emails_array = array_unique( $emails_array );
+    return $emails_array;
 }
 
 
@@ -1737,18 +1760,18 @@ function um_multi_admin_email() {
  * @return bool|string
  */
 function um_user_profile_url( $user_id = false ) {
-	if ( ! $user_id ) {
-		$user_id = um_user( 'ID' );
-	}
+    if ( ! $user_id ) {
+        $user_id = um_user( 'ID' );
+    }
 
-	$url = UM()->user()->get_profile_link( $user_id );
-	if ( empty( $url ) ) {
-		//if empty profile slug - generate it and re-get profile URL
-		UM()->user()->generate_profile_slug( $user_id );
-		$url = UM()->user()->get_profile_link( $user_id );
-	}
+    $url = UM()->user()->get_profile_link( $user_id );
+    if ( empty( $url ) ) {
+        //if empty profile slug - generate it and re-get profile URL
+        UM()->user()->generate_profile_slug( $user_id );
+        $url = UM()->user()->get_profile_link( $user_id );
+    }
 
-	return $url;
+    return $url;
 }
 
 
@@ -1758,7 +1781,7 @@ function um_user_profile_url( $user_id = false ) {
  * @return array
  */
 function um_get_roles() {
-	return UM()->roles()->get_roles();
+    return UM()->roles()->get_roles();
 }
 
 
@@ -1794,7 +1817,7 @@ function um_get_roles() {
  *
  */
 function um_fetch_user( $user_id ) {
-	UM()->user()->set( $user_id );
+    UM()->user()->set( $user_id );
 }
 
 
@@ -1806,53 +1829,53 @@ function um_fetch_user( $user_id ) {
  * @return bool|string
  */
 function um_profile( $key ) {
-	if ( ! empty( UM()->user()->profile[ $key ] ) ) {
-		/**
-		 * UM hook
-		 *
-		 * @type filter
-		 * @title um_profile_{$key}__filter
-		 * @description Change not empty profile field value
-		 * @input_vars
-		 * [{"var":"$value","type":"mixed","desc":"Profile Value"}]
-		 * @change_log
-		 * ["Since: 2.0"]
-		 * @usage add_filter( 'um_profile_{$key}__filter', 'function_name', 10, 1 );
-		 * @example
-		 * <?php
-		 * add_filter( 'um_profile_{$key}__filter', 'my_profile_value', 10, 1 );
-		 * function my_profile_value( $value ) {
-		 *     // your code here
-		 *     return $value;
-		 * }
-		 * ?>
-		 */
-		$value = apply_filters( "um_profile_{$key}__filter", UM()->user()->profile[ $key ] );
-	} else {
-		/**
-		 * UM hook
-		 *
-		 * @type filter
-		 * @title um_profile_{$key}_empty__filter
-		 * @description Change Profile field value if it's empty
-		 * @input_vars
-		 * [{"var":"$value","type":"mixed","desc":"Profile Value"}]
-		 * @change_log
-		 * ["Since: 2.0"]
-		 * @usage add_filter( 'um_profile_{$key}_empty__filter', 'function_name', 10, 1 );
-		 * @example
-		 * <?php
-		 * add_filter( 'um_profile_{$key}_empty__filter', 'my_profile_value', 10, 1 );
-		 * function my_profile_value( $value ) {
-		 *     // your code here
-		 *     return $value;
-		 * }
-		 * ?>
-		 */
-		$value = apply_filters( "um_profile_{$key}_empty__filter", false );
-	}
+    if ( ! empty( UM()->user()->profile[ $key ] ) ) {
+        /**
+         * UM hook
+         *
+         * @type filter
+         * @title um_profile_{$key}__filter
+         * @description Change not empty profile field value
+         * @input_vars
+         * [{"var":"$value","type":"mixed","desc":"Profile Value"}]
+         * @change_log
+         * ["Since: 2.0"]
+         * @usage add_filter( 'um_profile_{$key}__filter', 'function_name', 10, 1 );
+         * @example
+         * <?php
+         * add_filter( 'um_profile_{$key}__filter', 'my_profile_value', 10, 1 );
+         * function my_profile_value( $value ) {
+         *     // your code here
+         *     return $value;
+         * }
+         * ?>
+         */
+        $value = apply_filters( "um_profile_{$key}__filter", UM()->user()->profile[ $key ] );
+    } else {
+        /**
+         * UM hook
+         *
+         * @type filter
+         * @title um_profile_{$key}_empty__filter
+         * @description Change Profile field value if it's empty
+         * @input_vars
+         * [{"var":"$value","type":"mixed","desc":"Profile Value"}]
+         * @change_log
+         * ["Since: 2.0"]
+         * @usage add_filter( 'um_profile_{$key}_empty__filter', 'function_name', 10, 1 );
+         * @example
+         * <?php
+         * add_filter( 'um_profile_{$key}_empty__filter', 'my_profile_value', 10, 1 );
+         * function my_profile_value( $value ) {
+         *     // your code here
+         *     return $value;
+         * }
+         * ?>
+         */
+        $value = apply_filters( "um_profile_{$key}_empty__filter", false );
+    }
 
-	return $value;
+    return $value;
 }
 
 
@@ -1864,8 +1887,8 @@ function um_profile( $key ) {
  * @return bool
  */
 function um_youtube_id_from_url( $url ) {
-	$pattern =
-		'%^# Match any youtube URL
+    $pattern =
+        '%^# Match any youtube URL
 		(?:https?://)?  # Optional scheme. Either http or https
 		(?:www\.)?      # Optional www subdomain
 		(?:             # Group host alternatives
@@ -1879,12 +1902,12 @@ function um_youtube_id_from_url( $url ) {
 		)               # End host alternatives.
 		([\w-]{10,12})  # Allow 10-12 for 11 char youtube id.
 		$%x';
-	$result = preg_match( $pattern, $url, $matches );
-	if (false !== $result) {
-		return $matches[1];
-	}
+    $result = preg_match( $pattern, $url, $matches );
+    if (false !== $result) {
+        return $matches[1];
+    }
 
-	return false;
+    return false;
 }
 
 
@@ -1897,12 +1920,12 @@ function um_youtube_id_from_url( $url ) {
  * @return mixed
  */
 function um_closest_num( $array, $number ) {
-	sort( $array );
-	foreach ( $array as $a ) {
-		if ( $a >= $number ) return $a;
-	}
+    sort( $array );
+    foreach ( $array as $a ) {
+        if ( $a >= $number ) return $a;
+    }
 
-	return end( $array );
+    return end( $array );
 }
 
 
@@ -1915,46 +1938,46 @@ function um_closest_num( $array, $number ) {
  * @return bool|string
  */
 function um_get_cover_uri( $image, $attrs ) {
-	$uri = false;
-	$uri_common = false;
-	$ext = '.' . pathinfo( $image, PATHINFO_EXTENSION );
+    $uri = false;
+    $uri_common = false;
+    $ext = '.' . pathinfo( $image, PATHINFO_EXTENSION );
 
-	$ratio = str_replace(':1','',UM()->options()->get( 'profile_cover_ratio' ) );
-	$height = round( $attrs / $ratio );
+    $ratio = str_replace(':1','',UM()->options()->get( 'profile_cover_ratio' ) );
+    $height = round( $attrs / $ratio );
 
-	if ( is_multisite() ) {
-		//multisite fix for old customers
-		$multisite_fix_dir = UM()->uploader()->get_upload_base_dir();
-		$multisite_fix_url = UM()->uploader()->get_upload_base_url();
-		$multisite_fix_dir = str_replace( DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . get_current_blog_id() . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, $multisite_fix_dir );
-		$multisite_fix_url = str_replace( '/sites/' . get_current_blog_id() . '/', '/', $multisite_fix_url );
+    if ( is_multisite() ) {
+        //multisite fix for old customers
+        $multisite_fix_dir = UM()->uploader()->get_upload_base_dir();
+        $multisite_fix_url = UM()->uploader()->get_upload_base_url();
+        $multisite_fix_dir = str_replace( DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . get_current_blog_id() . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, $multisite_fix_dir );
+        $multisite_fix_url = str_replace( '/sites/' . get_current_blog_id() . '/', '/', $multisite_fix_url );
 
-		if ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo{$ext}" ) ) {
-			$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/cover_photo{$ext}?" . current_time( 'timestamp' );
-		}
+        if ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo{$ext}" ) ) {
+            $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/cover_photo{$ext}?" . current_time( 'timestamp' );
+        }
 
-		if ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}{$ext}" ) ) {
-			$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/cover_photo-{$attrs}{$ext}?" . current_time( 'timestamp' );
-		}elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}x{$height}{$ext}" ) ) {
-			$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/cover_photo-{$attrs}x{$height}{$ext}?". current_time( 'timestamp' );
-		}
-	}
+        if ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}{$ext}" ) ) {
+            $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/cover_photo-{$attrs}{$ext}?" . current_time( 'timestamp' );
+        }elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}x{$height}{$ext}" ) ) {
+            $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/cover_photo-{$attrs}x{$height}{$ext}?". current_time( 'timestamp' );
+        }
+    }
 
-	if ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo{$ext}" ) ) {
-		$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/cover_photo{$ext}?" . current_time( 'timestamp' );
-	}
+    if ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo{$ext}" ) ) {
+        $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/cover_photo{$ext}?" . current_time( 'timestamp' );
+    }
 
-	if ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}{$ext}" ) ) {
-		$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/cover_photo-{$attrs}{$ext}?" . current_time( 'timestamp' );
-	}elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}x{$height}{$ext}" ) ) {
-		$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/cover_photo-{$attrs}x{$height}{$ext}?". current_time( 'timestamp' );
-	}
+    if ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}{$ext}" ) ) {
+        $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/cover_photo-{$attrs}{$ext}?" . current_time( 'timestamp' );
+    }elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}x{$height}{$ext}" ) ) {
+        $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/cover_photo-{$attrs}x{$height}{$ext}?". current_time( 'timestamp' );
+    }
 
-	if ( ! empty( $uri_common ) && empty( $uri ) ) {
-		$uri = $uri_common;
-	}
+    if ( ! empty( $uri_common ) && empty( $uri ) ) {
+        $uri = $uri_common;
+    }
 
-	return $uri;
+    return $uri;
 }
 
 
@@ -1967,9 +1990,9 @@ function um_get_cover_uri( $image, $attrs ) {
  * @return mixed
  */
 function um_get_avatar_url( $get_avatar ) {
-	preg_match( '/src="(.*?)"/i', $get_avatar, $matches );
+    preg_match( '/src="(.*?)"/i', $get_avatar, $matches );
 
-	return isset( $matches[1] ) ? $matches[1] : '';
+    return isset( $matches[1] ) ? $matches[1] : '';
 }
 
 
@@ -1982,92 +2005,92 @@ function um_get_avatar_url( $get_avatar ) {
  * @return bool|string
  */
 function um_get_avatar_uri( $image, $attrs ) {
-	$uri = false;
-	$uri_common = false;
-	$find = false;
-	$ext = '.' . pathinfo( $image, PATHINFO_EXTENSION );
+    $uri = false;
+    $uri_common = false;
+    $find = false;
+    $ext = '.' . pathinfo( $image, PATHINFO_EXTENSION );
 
-	if ( is_multisite() ) {
-		//multisite fix for old customers
-		$multisite_fix_dir = UM()->uploader()->get_upload_base_dir();
-		$multisite_fix_url = UM()->uploader()->get_upload_base_url();
-		$multisite_fix_dir = str_replace( DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . get_current_blog_id() . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, $multisite_fix_dir );
-		$multisite_fix_url = str_replace( '/sites/' . get_current_blog_id() . '/', '/', $multisite_fix_url );
+    if ( is_multisite() ) {
+        //multisite fix for old customers
+        $multisite_fix_dir = UM()->uploader()->get_upload_base_dir();
+        $multisite_fix_url = UM()->uploader()->get_upload_base_url();
+        $multisite_fix_dir = str_replace( DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . get_current_blog_id() . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, $multisite_fix_dir );
+        $multisite_fix_url = str_replace( '/sites/' . get_current_blog_id() . '/', '/', $multisite_fix_url );
 
-		if ( $attrs == 'original' && file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
-			$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo{$ext}";
-		} elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}x{$attrs}{$ext}" ) ) {
-			$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$attrs}x{$attrs}{$ext}";
-		} elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}{$ext}" ) ) {
-			$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$attrs}{$ext}";
-		} else {
-			$sizes = UM()->options()->get( 'photo_thumb_sizes' );
-			if ( is_array( $sizes ) ) {
-				$find = um_closest_num( $sizes, $attrs );
-			}
+        if ( $attrs == 'original' && file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
+            $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo{$ext}";
+        } elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}x{$attrs}{$ext}" ) ) {
+            $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$attrs}x{$attrs}{$ext}";
+        } elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}{$ext}" ) ) {
+            $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$attrs}{$ext}";
+        } else {
+            $sizes = UM()->options()->get( 'photo_thumb_sizes' );
+            if ( is_array( $sizes ) ) {
+                $find = um_closest_num( $sizes, $attrs );
+            }
 
-			if ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}x{$find}{$ext}" ) ) {
-				$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$find}x{$find}{$ext}";
-			} elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}{$ext}" ) ) {
-				$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$find}{$ext}";
-			} elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
-				$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo{$ext}";
-			}
-		}
-	}
+            if ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}x{$find}{$ext}" ) ) {
+                $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$find}x{$find}{$ext}";
+            } elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}{$ext}" ) ) {
+                $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$find}{$ext}";
+            } elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
+                $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo{$ext}";
+            }
+        }
+    }
 
-	if ( $attrs == 'original' && file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
-		$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo{$ext}";
-	} elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}x{$attrs}{$ext}" ) ) {
-		$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$attrs}x{$attrs}{$ext}";
-	} elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}{$ext}" ) ) {
-		$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$attrs}{$ext}";
-	} else {
-		$sizes = UM()->options()->get( 'photo_thumb_sizes' );
-		if ( is_array( $sizes ) ) {
-			$find = um_closest_num( $sizes, $attrs );
-		}
+    if ( $attrs == 'original' && file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
+        $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo{$ext}";
+    } elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}x{$attrs}{$ext}" ) ) {
+        $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$attrs}x{$attrs}{$ext}";
+    } elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}{$ext}" ) ) {
+        $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$attrs}{$ext}";
+    } else {
+        $sizes = UM()->options()->get( 'photo_thumb_sizes' );
+        if ( is_array( $sizes ) ) {
+            $find = um_closest_num( $sizes, $attrs );
+        }
 
-		if ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}x{$find}{$ext}" ) ) {
-			$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$find}x{$find}{$ext}";
-		} elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}{$ext}" ) ) {
-			$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$find}{$ext}";
-		} elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
-			$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo{$ext}";
-		}
-	}
+        if ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}x{$find}{$ext}" ) ) {
+            $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$find}x{$find}{$ext}";
+        } elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}{$ext}" ) ) {
+            $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$find}{$ext}";
+        } elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
+            $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo{$ext}";
+        }
+    }
 
-	if ( ! empty( $uri_common ) && empty( $uri ) ) {
-		$uri = $uri_common;
-	}
+    if ( ! empty( $uri_common ) && empty( $uri ) ) {
+        $uri = $uri_common;
+    }
 
-	/**
-	 * UM hook
-	 *
-	 * @type filter
-	 * @title um_filter_avatar_cache_time
-	 * @description Change Profile field value if it's empty
-	 * @input_vars
-	 * [{"var":"$timestamp","type":"timestamp","desc":"Avatar cache time"},
-	 * {"var":"$user_id","type":"int","desc":"User ID"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_filter_avatar_cache_time', 'function_name', 10, 2 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_filter_avatar_cache_time', 'my_avatar_cache_time', 10, 2 );
-	 * function my_avatar_cache_time( $timestamp, $user_id ) {
-	 *     // your code here
-	 *     return $timestamp;
-	 * }
-	 * ?>
-	 */
-	$cache_time = apply_filters( 'um_filter_avatar_cache_time', current_time( 'timestamp' ), um_user( 'ID' ) );
-	if ( ! empty( $cache_time ) ) {
-		$uri .= "?{$cache_time}";
-	}
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_filter_avatar_cache_time
+     * @description Change Profile field value if it's empty
+     * @input_vars
+     * [{"var":"$timestamp","type":"timestamp","desc":"Avatar cache time"},
+     * {"var":"$user_id","type":"int","desc":"User ID"}]
+     * @change_log
+     * ["Since: 2.0"]
+     * @usage add_filter( 'um_filter_avatar_cache_time', 'function_name', 10, 2 );
+     * @example
+     * <?php
+     * add_filter( 'um_filter_avatar_cache_time', 'my_avatar_cache_time', 10, 2 );
+     * function my_avatar_cache_time( $timestamp, $user_id ) {
+     *     // your code here
+     *     return $timestamp;
+     * }
+     * ?>
+     */
+    $cache_time = apply_filters( 'um_filter_avatar_cache_time', current_time( 'timestamp' ), um_user( 'ID' ) );
+    if ( ! empty( $cache_time ) ) {
+        $uri .= "?{$cache_time}";
+    }
 
-	return $uri;
+    return $uri;
 }
 
 
@@ -2077,13 +2100,13 @@ function um_get_avatar_uri( $image, $attrs ) {
  * @return string
  */
 function um_get_default_avatar_uri() {
-	$uri = UM()->options()->get( 'default_avatar' );
-	$uri = !empty( $uri['url'] ) ? $uri['url'] : '';
-	if ( ! $uri ) {
-		$uri = um_url . 'assets/img/default_avatar.jpg';
-	}
+    $uri = UM()->options()->get( 'default_avatar' );
+    $uri = !empty( $uri['url'] ) ? $uri['url'] : '';
+    if ( ! $uri ) {
+        $uri = um_url . 'assets/img/default_avatar.jpg';
+    }
 
-	return set_url_scheme( $uri );
+    return set_url_scheme( $uri );
 }
 
 
@@ -2096,105 +2119,105 @@ function um_get_default_avatar_uri() {
  * @return bool|string
  */
 function um_get_user_avatar_data( $user_id = '', $size = '96' ) {
-	if( empty( $user_id ) ) {
-		$user_id = um_user( 'ID' );
-	} else {
-		um_fetch_user( $user_id );
-	}
+    if( empty( $user_id ) ) {
+        $user_id = um_user( 'ID' );
+    } else {
+        um_fetch_user( $user_id );
+    }
 
-	$data = array(
-		'user_id'   => $user_id,
-		'default'   => um_get_default_avatar_uri(),
-		'class'     => 'gravatar avatar avatar-' . $size . ' um-avatar',
-		'size'      => $size
-	);
+    $data = array(
+        'user_id'   => $user_id,
+        'default'   => um_get_default_avatar_uri(),
+        'class'     => 'gravatar avatar avatar-' . $size . ' um-avatar',
+        'size'      => $size
+    );
 
-	if ( $profile_photo = um_profile( 'profile_photo' ) ) {
-		$data['url'] = um_get_avatar_uri( $profile_photo, $size );
-		$data['type'] = 'upload';
-		$data['class'] .= ' um-avatar-uploaded';
-	} elseif ( $synced_profile_photo = um_user( 'synced_profile_photo' ) ) {
-		$data['url'] = $synced_profile_photo;
-		$data['type'] = 'sync';
-		$data['class'] .= ' um-avatar-default';
-	} elseif ( UM()->options()->get( 'use_gravatars' ) ) {
-		$avatar_hash_id = md5( um_user( 'user_email' ) );
-		$data['url'] = set_url_scheme( '//gravatar.com/avatar/' . $avatar_hash_id );
-		$data['url'] = add_query_arg( 's', 400, $data['url'] );
-		$rating = get_option( 'avatar_rating' );
-		if ( ! empty( $rating ) ) {
-			$data['url'] = add_query_arg( 'r', $rating, $data['url'] );
-		}
+    if ( $profile_photo = um_profile( 'profile_photo' ) ) {
+        $data['url'] = um_get_avatar_uri( $profile_photo, $size );
+        $data['type'] = 'upload';
+        $data['class'] .= ' um-avatar-uploaded';
+    } elseif ( $synced_profile_photo = um_user( 'synced_profile_photo' ) ) {
+        $data['url'] = $synced_profile_photo;
+        $data['type'] = 'sync';
+        $data['class'] .= ' um-avatar-default';
+    } elseif ( UM()->options()->get( 'use_gravatars' ) ) {
+        $avatar_hash_id = md5( um_user( 'user_email' ) );
+        $data['url'] = set_url_scheme( '//gravatar.com/avatar/' . $avatar_hash_id );
+        $data['url'] = add_query_arg( 's', 400, $data['url'] );
+        $rating = get_option( 'avatar_rating' );
+        if ( ! empty( $rating ) ) {
+            $data['url'] = add_query_arg( 'r', $rating, $data['url'] );
+        }
 
-		$gravatar_type = UM()->options()->get( 'use_um_gravatar_default_builtin_image' );
-		if ( $gravatar_type == 'default' ) {
-			if ( UM()->options()->get( 'use_um_gravatar_default_image' ) ) {
-				$data['url'] = add_query_arg( 'd', $data['default'], $data['url'] );
-			} else {
-				$default = get_option( 'avatar_default', 'mystery' );
-				if ( $default == 'gravatar_default' ) {
-					$default = '';
-				}
-				$data['url'] = add_query_arg( 'd', $default, $data['url'] );
-			}
-		} else {
-			$data['url'] = add_query_arg( 'd', $gravatar_type, $data['url'] );
-		}
+        $gravatar_type = UM()->options()->get( 'use_um_gravatar_default_builtin_image' );
+        if ( $gravatar_type == 'default' ) {
+            if ( UM()->options()->get( 'use_um_gravatar_default_image' ) ) {
+                $data['url'] = add_query_arg( 'd', $data['default'], $data['url'] );
+            } else {
+                $default = get_option( 'avatar_default', 'mystery' );
+                if ( $default == 'gravatar_default' ) {
+                    $default = '';
+                }
+                $data['url'] = add_query_arg( 'd', $default, $data['url'] );
+            }
+        } else {
+            $data['url'] = add_query_arg( 'd', $gravatar_type, $data['url'] );
+        }
 
-		$data['type'] = 'gravatar';
-		$data['class'] .= ' um-avatar-gravatar';
-	} else {
-		$data['url'] = $data['default'];
-		$data['type'] = 'default';
-		$data['class'] .= ' um-avatar-default';
-	}
+        $data['type'] = 'gravatar';
+        $data['class'] .= ' um-avatar-gravatar';
+    } else {
+        $data['url'] = $data['default'];
+        $data['type'] = 'default';
+        $data['class'] .= ' um-avatar-default';
+    }
 
 
-	/**
-	 * UM hook
-	 *
-	 * @type filter
-	 * @title um_user_avatar_url_filter
-	 * @description Change user avatar URL
-	 * @input_vars
-	 * [{"var":"$avatar_uri","type":"string","desc":"Avatar URL"},
-	 * {"var":"$user_id","type":"int","desc":"User ID"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_user_avatar_url_filter', 'function_name', 10, 2 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_user_avatar_url_filter', 'my_user_avatar_url', 10, 2 );
-	 * function my_user_avatar_url( $avatar_uri ) {
-	 *     // your code here
-	 *     return $avatar_uri;
-	 * }
-	 * ?>
-	 */
-	$data['url'] = apply_filters( 'um_user_avatar_url_filter', $data['url'], $user_id, $data );
-	/**
-	 * UM hook
-	 *
-	 * @type filter
-	 * @title um_avatar_image_alternate_text
-	 * @description Change user display name on um_user function profile photo
-	 * @input_vars
-	 * [{"var":"$display_name","type":"string","desc":"User Display Name"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_avatar_image_alternate_text', 'function_name', 10, 1 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_avatar_image_alternate_text', 'my_avatar_image_alternate_text', 10, 1 );
-	 * function my_avatar_image_alternate_text( $display_name ) {
-	 *     // your code here
-	 *     return $display_name;
-	 * }
-	 * ?>
-	 */
-	$data['alt'] = apply_filters( "um_avatar_image_alternate_text", um_user( "display_name" ), $data );
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_user_avatar_url_filter
+     * @description Change user avatar URL
+     * @input_vars
+     * [{"var":"$avatar_uri","type":"string","desc":"Avatar URL"},
+     * {"var":"$user_id","type":"int","desc":"User ID"}]
+     * @change_log
+     * ["Since: 2.0"]
+     * @usage add_filter( 'um_user_avatar_url_filter', 'function_name', 10, 2 );
+     * @example
+     * <?php
+     * add_filter( 'um_user_avatar_url_filter', 'my_user_avatar_url', 10, 2 );
+     * function my_user_avatar_url( $avatar_uri ) {
+     *     // your code here
+     *     return $avatar_uri;
+     * }
+     * ?>
+     */
+    $data['url'] = apply_filters( 'um_user_avatar_url_filter', $data['url'], $user_id, $data );
+    /**
+     * UM hook
+     *
+     * @type filter
+     * @title um_avatar_image_alternate_text
+     * @description Change user display name on um_user function profile photo
+     * @input_vars
+     * [{"var":"$display_name","type":"string","desc":"User Display Name"}]
+     * @change_log
+     * ["Since: 2.0"]
+     * @usage add_filter( 'um_avatar_image_alternate_text', 'function_name', 10, 1 );
+     * @example
+     * <?php
+     * add_filter( 'um_avatar_image_alternate_text', 'my_avatar_image_alternate_text', 10, 1 );
+     * function my_avatar_image_alternate_text( $display_name ) {
+     *     // your code here
+     *     return $display_name;
+     * }
+     * ?>
+     */
+    $data['alt'] = apply_filters( "um_avatar_image_alternate_text", um_user( "display_name" ), $data );
 
-	return $data;
+    return $data;
 }
 
 
@@ -2207,8 +2230,8 @@ function um_get_user_avatar_data( $user_id = '', $size = '96' ) {
  * @return bool|string
  */
 function um_get_user_avatar_url( $user_id = '', $size = '96' ) {
-	$data = um_get_user_avatar_data( $user_id, $size );
-	return $data['url'];
+    $data = um_get_user_avatar_data( $user_id, $size );
+    return $data['url'];
 }
 
 
@@ -2218,34 +2241,34 @@ function um_get_user_avatar_url( $user_id = '', $size = '96' ) {
  * @return mixed|string|void
  */
 function um_get_default_cover_uri() {
-	$uri = UM()->options()->get( 'default_cover' );
-	$uri = ! empty( $uri['url'] ) ? $uri['url'] : '';
-	if ( $uri ) {
+    $uri = UM()->options()->get( 'default_cover' );
+    $uri = ! empty( $uri['url'] ) ? $uri['url'] : '';
+    if ( $uri ) {
 
-		/**
-		 * UM hook
-		 *
-		 * @type filter
-		 * @title um_get_default_cover_uri_filter
-		 * @description Change Default Cover URL
-		 * @input_vars
-		 * [{"var":"$uri","type":"string","desc":"Default Cover URL"}]
-		 * @change_log
-		 * ["Since: 2.0"]
-		 * @usage add_filter( 'um_get_default_cover_uri_filter', 'function_name', 10, 1 );
-		 * @example
-		 * <?php
-		 * add_filter( 'um_get_default_cover_uri_filter', 'my_default_cover_uri', 10, 1 );
-		 * function my_default_cover_uri( $uri ) {
-		 *     // your code here
-		 *     return $uri;
-		 * }
-		 * ?>
-		 */
-		return apply_filters( 'um_get_default_cover_uri_filter', $uri );
-	}
+        /**
+         * UM hook
+         *
+         * @type filter
+         * @title um_get_default_cover_uri_filter
+         * @description Change Default Cover URL
+         * @input_vars
+         * [{"var":"$uri","type":"string","desc":"Default Cover URL"}]
+         * @change_log
+         * ["Since: 2.0"]
+         * @usage add_filter( 'um_get_default_cover_uri_filter', 'function_name', 10, 1 );
+         * @example
+         * <?php
+         * add_filter( 'um_get_default_cover_uri_filter', 'my_default_cover_uri', 10, 1 );
+         * function my_default_cover_uri( $uri ) {
+         *     // your code here
+         *     return $uri;
+         * }
+         * ?>
+         */
+        return apply_filters( 'um_get_default_cover_uri_filter', $uri );
+    }
 
-	return '';
+    return '';
 }
 
 
@@ -2257,327 +2280,327 @@ function um_get_default_cover_uri() {
  */
 function um_user( $data, $attrs = null ) {
 
-	switch ($data) {
+    switch ($data) {
 
-		default:
+        default:
 
-			$value = um_profile( $data );
+            $value = um_profile( $data );
 
-			$value = maybe_unserialize( $value );
+            $value = maybe_unserialize( $value );
 
-			if ( in_array( $data, array( 'role', 'gender' ) ) ) {
-				if ( is_array( $value ) ) {
-					$value = implode( ",", $value );
-				}
+            if ( in_array( $data, array( 'role', 'gender' ) ) ) {
+                if ( is_array( $value ) ) {
+                    $value = implode( ",", $value );
+                }
 
-				return $value;
-			}
+                return $value;
+            }
 
-			return $value;
-			break;
+            return $value;
+            break;
 
-		case 'user_email':
+        case 'user_email':
 
-			$user_email_in_meta = get_user_meta( um_user( 'ID' ), 'user_email', true );
-			if ( $user_email_in_meta ) {
-				delete_user_meta( um_user( 'ID' ), 'user_email' );
-			}
+            $user_email_in_meta = get_user_meta( um_user( 'ID' ), 'user_email', true );
+            if ( $user_email_in_meta ) {
+                delete_user_meta( um_user( 'ID' ), 'user_email' );
+            }
 
-			$value = um_profile( $data );
+            $value = um_profile( $data );
 
-			return $value;
-			break;
+            return $value;
+            break;
 
-		case 'user_login':
+        case 'user_login':
 
-			$user_login_in_meta = get_user_meta( um_user( 'ID' ), 'user_login', true );
-			if ( $user_login_in_meta ) {
-				delete_user_meta( um_user( 'ID' ), 'user_login' );
-			}
+            $user_login_in_meta = get_user_meta( um_user( 'ID' ), 'user_login', true );
+            if ( $user_login_in_meta ) {
+                delete_user_meta( um_user( 'ID' ), 'user_login' );
+            }
 
-			$value = um_profile( $data );
+            $value = um_profile( $data );
 
-			return $value;
-			break;
+            return $value;
+            break;
 
-		case 'first_name':
-		case 'last_name':
+        case 'first_name':
+        case 'last_name':
 
-			$name = um_profile( $data );
+            $name = um_profile( $data );
 
-			if ( UM()->options()->get( 'force_display_name_capitlized' ) ) {
-				$name = implode( '-', array_map( 'ucfirst', explode( '-', $name ) ) );
-			}
+            if ( UM()->options()->get( 'force_display_name_capitlized' ) ) {
+                $name = implode( '-', array_map( 'ucfirst', explode( '-', $name ) ) );
+            }
 
-			/**
-			 * UM hook
-			 *
-			 * @type filter
-			 * @title um_user_{$data}_case
-			 * @description Change user name on um_user function
-			 * @input_vars
-			 * [{"var":"$name","type":"string","desc":"User Name"}]
-			 * @change_log
-			 * ["Since: 2.0"]
-			 * @usage add_filter( 'um_user_{$data}_case', 'function_name', 10, 1 );
-			 * @example
-			 * <?php
-			 * add_filter( 'um_user_{$data}_case', 'my_user_case', 10, 1 );
-			 * function my_user_case( $name ) {
-			 *     // your code here
-			 *     return $name;
-			 * }
-			 * ?>
-			 */
-			$name = apply_filters( "um_user_{$data}_case", $name );
-
-			return $name;
+            /**
+             * UM hook
+             *
+             * @type filter
+             * @title um_user_{$data}_case
+             * @description Change user name on um_user function
+             * @input_vars
+             * [{"var":"$name","type":"string","desc":"User Name"}]
+             * @change_log
+             * ["Since: 2.0"]
+             * @usage add_filter( 'um_user_{$data}_case', 'function_name', 10, 1 );
+             * @example
+             * <?php
+             * add_filter( 'um_user_{$data}_case', 'my_user_case', 10, 1 );
+             * function my_user_case( $name ) {
+             *     // your code here
+             *     return $name;
+             * }
+             * ?>
+             */
+            $name = apply_filters( "um_user_{$data}_case", $name );
+
+            return $name;
 
-			break;
-
-		case 'full_name':
-
-			if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
-				$full_name = um_user( 'first_name' ) . ' ' . um_user( 'last_name' );
-			} else {
-				$full_name = um_user( 'display_name' );
-			}
-
-			$full_name = UM()->validation()->safe_name_in_url( $full_name );
-
-			// update full_name changed
-			if ( um_profile( $data ) !== $full_name ) {
-				update_user_meta( um_user( 'ID' ), 'full_name', $full_name );
-			}
-
-			return $full_name;
-
-			break;
-
-		case 'first_and_last_name_initial':
-
-			$f_and_l_initial = '';
-
-			if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
-				$initial = um_user( 'last_name' );
-				$f_and_l_initial = um_user( 'first_name' ) . ' ' . $initial[0];
-			} else {
-				$f_and_l_initial = um_profile( $data );
-			}
-
-			$f_and_l_initial = UM()->validation()->safe_name_in_url( $f_and_l_initial );
-
-			if ( UM()->options()->get( 'force_display_name_capitlized' ) ) {
-				$name = implode( '-', array_map( 'ucfirst', explode( '-', $f_and_l_initial ) ) );
-			} else {
-				$name = $f_and_l_initial;
-			}
-
-			return $name;
-
-			break;
-
-		case 'display_name':
-
-			$op = UM()->options()->get( 'display_name' );
-
-			$name = '';
-
-			if ( $op == 'default' ) {
-				$name = um_profile( 'display_name' );
-			}
-
-			if ( $op == 'nickname' ) {
-				$name = um_profile( 'nickname' );
-			}
-
-			if ( $op == 'full_name' ) {
-				if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
-					$name = um_user( 'first_name' ) . ' ' . um_user( 'last_name' );
-				} else {
-					$name = um_profile( $data );
-				}
-				if ( ! $name ) {
-					$name = um_user( 'user_login' );
-				}
-			}
-
-			if ( $op == 'sur_name' ) {
-				if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
-					$name = um_user( 'last_name' ) . ' ' . um_user( 'first_name' );
-				} else {
-					$name = um_profile( $data );
-				}
-			}
-
-			if ( $op == 'first_name' ) {
-				if ( um_user( 'first_name' ) ) {
-					$name = um_user( 'first_name' );
-				} else {
-					$name = um_profile( $data );
-				}
-			}
-
-			if ( $op == 'username' ) {
-				$name = um_user( 'user_login' );
-			}
-
-			if ( $op == 'initial_name' ) {
-				if (um_user( 'first_name' ) && um_user( 'last_name' )) {
-					$initial = um_user( 'last_name' );
-					$name = um_user( 'first_name' ) . ' ' . $initial[0];
-				} else {
-					$name = um_profile( $data );
-				}
-			}
-
-			if ( $op == 'initial_name_f' ) {
-				if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
-					$initial = um_user( 'first_name' );
-					$name = $initial[0] . ' ' . um_user( 'last_name' );
-				} else {
-					$name = um_profile( $data );
-				}
-			}
-
-
-			if ( $op == 'field' && UM()->options()->get( 'display_name_field' ) != '' ) {
-				$fields = array_filter( preg_split( '/[,\s]+/', UM()->options()->get( 'display_name_field' ) ) );
-				$name = '';
-
-				foreach ( $fields as $field ) {
-					if ( um_profile( $field ) ) {
-						$name .= um_profile( $field ) . ' ';
-					} elseif ( um_user( $field ) && $field != 'display_name' && $field != 'full_name' ) {
-						$name .= um_user( $field ) . ' ';
-					}
-				}
-			}
-
-			if ( UM()->options()->get( 'force_display_name_capitlized' ) ) {
-				$name = implode( '-', array_map( 'ucfirst', explode( '-', $name ) ) );
-			}
-
-			/**
-			 * UM hook
-			 *
-			 * @type filter
-			 * @title um_user_display_name_filter
-			 * @description Change user display name on um_user function
-			 * @input_vars
-			 * [{"var":"$name","type":"string","desc":"User Name"},
-			 * {"var":"$user_id","type":"int","desc":"User ID"},
-			 * {"var":"$html","type":"bool","desc":"Is HTML"}]
-			 * @change_log
-			 * ["Since: 2.0"]
-			 * @usage add_filter( 'um_user_display_name_filter', 'function_name', 10, 3 );
-			 * @example
-			 * <?php
-			 * add_filter( 'um_user_display_name_filter', 'my_user_display_name', 10, 3 );
-			 * function my_user_display_name( $name, $user_id, $html ) {
-			 *     // your code here
-			 *     return $name;
-			 * }
-			 * ?>
-			 */
-			return apply_filters( 'um_user_display_name_filter', $name, um_user( 'ID' ), ( $attrs == 'html' ) ? 1 : 0 );
-
-			break;
-
-		case 'role_select':
-		case 'role_radio':
-
-			return UM()->roles()->get_role_name( UM()->roles()->get_editable_priority_user_role( um_user( 'ID' ) ) );
-			break;
-
-		case 'submitted':
-			$array = um_profile( $data );
-			if ( empty( $array ) ) {
-				return '';
-			}
-			$array = maybe_unserialize( $array );
-
-			return $array;
-			break;
-
-		case 'password_reset_link':
-			return UM()->password()->reset_url();
-			break;
-
-		case 'account_activation_link':
-			return UM()->permalinks()->activate_url();
-			break;
-
-		case 'profile_photo':
-			$data = um_get_user_avatar_data( um_user( 'ID' ), $attrs );
-
-			return sprintf( '<img src="%s" class="%s" width="%s" height="%s" alt="%s" data-default="%s" onerror="%s" />',
-				esc_attr( $data['url'] ),
-				esc_attr( $data['class'] ),
-				esc_attr( $data['size'] ),
-				esc_attr( $data['size'] ),
-				esc_attr( $data['alt'] ),
-				esc_attr( $data['default'] ),
-				'if ( ! this.getAttribute(\'data-load-error\') ){ this.setAttribute(\'data-load-error\', \'1\');this.setAttribute(\'src\', this.getAttribute(\'data-default\'));}'
-			);
-			break;
-
-		case 'cover_photo':
-
-			$is_default = false;
-
-			if ( um_profile( 'cover_photo' ) ) {
-				$cover_uri = um_get_cover_uri( um_profile( 'cover_photo' ), $attrs );
-			} elseif ( um_profile( 'synced_cover_photo' ) ) {
-				$cover_uri = um_profile( 'synced_cover_photo' );
-			} else {
-				$cover_uri = um_get_default_cover_uri();
-				$is_default = true;
-			}
-
-			/**
-			 * UM hook
-			 *
-			 * @type filter
-			 * @title um_user_cover_photo_uri__filter
-			 * @description Change user avatar URL
-			 * @input_vars
-			 * [{"var":"$cover_uri","type":"string","desc":"Cover URL"},
-			 * {"var":"$is_default","type":"bool","desc":"Default or not"},
-			 * {"var":"$attrs","type":"array","desc":"Attributes"}]
-			 * @change_log
-			 * ["Since: 2.0"]
-			 * @usage add_filter( 'um_user_cover_photo_uri__filter', 'function_name', 10, 3 );
-			 * @example
-			 * <?php
-			 * add_filter( 'um_user_cover_photo_uri__filter', 'my_user_cover_photo_uri', 10, 3 );
-			 * function my_user_cover_photo_uri( $cover_uri, $is_default, $attrs ) {
-			 *     // your code here
-			 *     return $cover_uri;
-			 * }
-			 * ?>
-			 */
-			$cover_uri = apply_filters( 'um_user_cover_photo_uri__filter', $cover_uri, $is_default, $attrs );
-
-			$alt = um_profile( 'nickname' );
-
-			$cover_html = $cover_uri ? '<img src="' . esc_attr( $cover_uri ) . '" alt="' . esc_attr( $alt ) . '" />' : '';
-
-			$cover_html = apply_filters( 'um_user_cover_photo_html__filter', $cover_html, $cover_uri, $alt, $is_default, $attrs );
-			return $cover_html;
-
-			break;
-
-		case 'user_url':
-
-			$value = um_profile( $data );
-
-			return $value;
-
-			break;
-
-
-	}
+            break;
+
+        case 'full_name':
+
+            if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
+                $full_name = um_user( 'first_name' ) . ' ' . um_user( 'last_name' );
+            } else {
+                $full_name = um_user( 'display_name' );
+            }
+
+            $full_name = UM()->validation()->safe_name_in_url( $full_name );
+
+            // update full_name changed
+            if ( um_profile( $data ) !== $full_name ) {
+                update_user_meta( um_user( 'ID' ), 'full_name', $full_name );
+            }
+
+            return $full_name;
+
+            break;
+
+        case 'first_and_last_name_initial':
+
+            $f_and_l_initial = '';
+
+            if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
+                $initial = um_user( 'last_name' );
+                $f_and_l_initial = um_user( 'first_name' ) . ' ' . $initial[0];
+            } else {
+                $f_and_l_initial = um_profile( $data );
+            }
+
+            $f_and_l_initial = UM()->validation()->safe_name_in_url( $f_and_l_initial );
+
+            if ( UM()->options()->get( 'force_display_name_capitlized' ) ) {
+                $name = implode( '-', array_map( 'ucfirst', explode( '-', $f_and_l_initial ) ) );
+            } else {
+                $name = $f_and_l_initial;
+            }
+
+            return $name;
+
+            break;
+
+        case 'display_name':
+
+            $op = UM()->options()->get( 'display_name' );
+
+            $name = '';
+
+            if ( $op == 'default' ) {
+                $name = um_profile( 'display_name' );
+            }
+
+            if ( $op == 'nickname' ) {
+                $name = um_profile( 'nickname' );
+            }
+
+            if ( $op == 'full_name' ) {
+                if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
+                    $name = um_user( 'first_name' ) . ' ' . um_user( 'last_name' );
+                } else {
+                    $name = um_profile( $data );
+                }
+                if ( ! $name ) {
+                    $name = um_user( 'user_login' );
+                }
+            }
+
+            if ( $op == 'sur_name' ) {
+                if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
+                    $name = um_user( 'last_name' ) . ' ' . um_user( 'first_name' );
+                } else {
+                    $name = um_profile( $data );
+                }
+            }
+
+            if ( $op == 'first_name' ) {
+                if ( um_user( 'first_name' ) ) {
+                    $name = um_user( 'first_name' );
+                } else {
+                    $name = um_profile( $data );
+                }
+            }
+
+            if ( $op == 'username' ) {
+                $name = um_user( 'user_login' );
+            }
+
+            if ( $op == 'initial_name' ) {
+                if (um_user( 'first_name' ) && um_user( 'last_name' )) {
+                    $initial = um_user( 'last_name' );
+                    $name = um_user( 'first_name' ) . ' ' . $initial[0];
+                } else {
+                    $name = um_profile( $data );
+                }
+            }
+
+            if ( $op == 'initial_name_f' ) {
+                if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
+                    $initial = um_user( 'first_name' );
+                    $name = $initial[0] . ' ' . um_user( 'last_name' );
+                } else {
+                    $name = um_profile( $data );
+                }
+            }
+
+
+            if ( $op == 'field' && UM()->options()->get( 'display_name_field' ) != '' ) {
+                $fields = array_filter( preg_split( '/[,\s]+/', UM()->options()->get( 'display_name_field' ) ) );
+                $name = '';
+
+                foreach ( $fields as $field ) {
+                    if ( um_profile( $field ) ) {
+                        $name .= um_profile( $field ) . ' ';
+                    } elseif ( um_user( $field ) && $field != 'display_name' && $field != 'full_name' ) {
+                        $name .= um_user( $field ) . ' ';
+                    }
+                }
+            }
+
+            if ( UM()->options()->get( 'force_display_name_capitlized' ) ) {
+                $name = implode( '-', array_map( 'ucfirst', explode( '-', $name ) ) );
+            }
+
+            /**
+             * UM hook
+             *
+             * @type filter
+             * @title um_user_display_name_filter
+             * @description Change user display name on um_user function
+             * @input_vars
+             * [{"var":"$name","type":"string","desc":"User Name"},
+             * {"var":"$user_id","type":"int","desc":"User ID"},
+             * {"var":"$html","type":"bool","desc":"Is HTML"}]
+             * @change_log
+             * ["Since: 2.0"]
+             * @usage add_filter( 'um_user_display_name_filter', 'function_name', 10, 3 );
+             * @example
+             * <?php
+             * add_filter( 'um_user_display_name_filter', 'my_user_display_name', 10, 3 );
+             * function my_user_display_name( $name, $user_id, $html ) {
+             *     // your code here
+             *     return $name;
+             * }
+             * ?>
+             */
+            return apply_filters( 'um_user_display_name_filter', $name, um_user( 'ID' ), ( $attrs == 'html' ) ? 1 : 0 );
+
+            break;
+
+        case 'role_select':
+        case 'role_radio':
+
+            return UM()->roles()->get_role_name( UM()->roles()->get_editable_priority_user_role( um_user( 'ID' ) ) );
+            break;
+
+        case 'submitted':
+            $array = um_profile( $data );
+            if ( empty( $array ) ) {
+                return '';
+            }
+            $array = maybe_unserialize( $array );
+
+            return $array;
+            break;
+
+        case 'password_reset_link':
+            return UM()->password()->reset_url();
+            break;
+
+        case 'account_activation_link':
+            return UM()->permalinks()->activate_url();
+            break;
+
+        case 'profile_photo':
+            $data = um_get_user_avatar_data( um_user( 'ID' ), $attrs );
+
+            return sprintf( '<img src="%s" class="%s" width="%s" height="%s" alt="%s" data-default="%s" onerror="%s" />',
+                esc_attr( $data['url'] ),
+                esc_attr( $data['class'] ),
+                esc_attr( $data['size'] ),
+                esc_attr( $data['size'] ),
+                esc_attr( $data['alt'] ),
+                esc_attr( $data['default'] ),
+                'if ( ! this.getAttribute(\'data-load-error\') ){ this.setAttribute(\'data-load-error\', \'1\');this.setAttribute(\'src\', this.getAttribute(\'data-default\'));}'
+            );
+            break;
+
+        case 'cover_photo':
+
+            $is_default = false;
+
+            if ( um_profile( 'cover_photo' ) ) {
+                $cover_uri = um_get_cover_uri( um_profile( 'cover_photo' ), $attrs );
+            } elseif ( um_profile( 'synced_cover_photo' ) ) {
+                $cover_uri = um_profile( 'synced_cover_photo' );
+            } else {
+                $cover_uri = um_get_default_cover_uri();
+                $is_default = true;
+            }
+
+            /**
+             * UM hook
+             *
+             * @type filter
+             * @title um_user_cover_photo_uri__filter
+             * @description Change user avatar URL
+             * @input_vars
+             * [{"var":"$cover_uri","type":"string","desc":"Cover URL"},
+             * {"var":"$is_default","type":"bool","desc":"Default or not"},
+             * {"var":"$attrs","type":"array","desc":"Attributes"}]
+             * @change_log
+             * ["Since: 2.0"]
+             * @usage add_filter( 'um_user_cover_photo_uri__filter', 'function_name', 10, 3 );
+             * @example
+             * <?php
+             * add_filter( 'um_user_cover_photo_uri__filter', 'my_user_cover_photo_uri', 10, 3 );
+             * function my_user_cover_photo_uri( $cover_uri, $is_default, $attrs ) {
+             *     // your code here
+             *     return $cover_uri;
+             * }
+             * ?>
+             */
+            $cover_uri = apply_filters( 'um_user_cover_photo_uri__filter', $cover_uri, $is_default, $attrs );
+
+            $alt = um_profile( 'nickname' );
+
+            $cover_html = $cover_uri ? '<img src="' . esc_attr( $cover_uri ) . '" alt="' . esc_attr( $alt ) . '" />' : '';
+
+            $cover_html = apply_filters( 'um_user_cover_photo_html__filter', $cover_html, $cover_uri, $alt, $is_default, $attrs );
+            return $cover_html;
+
+            break;
+
+        case 'user_url':
+
+            $value = um_profile( $data );
+
+            return $value;
+
+            break;
+
+
+    }
 
 }
 
@@ -2589,13 +2612,13 @@ function um_user( $data, $attrs = null ) {
  */
 function um_get_domain_protocol() {
 
-	if (is_ssl()) {
-		$protocol = 'https://';
-	} else {
-		$protocol = 'http://';
-	}
+    if (is_ssl()) {
+        $protocol = 'https://';
+    } else {
+        $protocol = 'http://';
+    }
 
-	return $protocol;
+    return $protocol;
 }
 
 
@@ -2608,11 +2631,11 @@ function um_get_domain_protocol() {
  */
 function um_secure_media_uri( $url ) {
 
-	if (is_ssl()) {
-		$url = str_replace( 'http:', 'https:', $url );
-	}
+    if (is_ssl()) {
+        $url = str_replace( 'http:', 'https:', $url );
+    }
 
-	return $url;
+    return $url;
 }
 
 
@@ -2625,30 +2648,30 @@ function um_secure_media_uri( $url ) {
  */
 function um_force_utf8_string( $value ) {
 
-	if (is_array( $value )) {
-		$arr_value = array();
-		foreach ($value as $key => $value) {
-			$utf8_decoded_value = utf8_decode( $value );
+    if (is_array( $value )) {
+        $arr_value = array();
+        foreach ($value as $key => $value) {
+            $utf8_decoded_value = utf8_decode( $value );
 
-			if (mb_check_encoding( $utf8_decoded_value, 'UTF-8' )) {
-				array_push( $arr_value, $utf8_decoded_value );
-			} else {
-				array_push( $arr_value, $value );
-			}
+            if (mb_check_encoding( $utf8_decoded_value, 'UTF-8' )) {
+                array_push( $arr_value, $utf8_decoded_value );
+            } else {
+                array_push( $arr_value, $value );
+            }
 
-		}
+        }
 
-		return $arr_value;
-	} else {
+        return $arr_value;
+    } else {
 
-		$utf8_decoded_value = utf8_decode( $value );
+        $utf8_decoded_value = utf8_decode( $value );
 
-		if (mb_check_encoding( $utf8_decoded_value, 'UTF-8' )) {
-			return $utf8_decoded_value;
-		}
-	}
+        if (mb_check_encoding( $utf8_decoded_value, 'UTF-8' )) {
+            return $utf8_decoded_value;
+        }
+    }
 
-	return $value;
+    return $value;
 }
 
 
@@ -2661,36 +2684,36 @@ function um_force_utf8_string( $value ) {
  * @return mixed string $host if detected, false otherwise
  */
 function um_get_host() {
-	$host = false;
+    $host = false;
 
-	if (defined( 'WPE_APIKEY' )) {
-		$host = 'WP Engine';
-	} else if (defined( 'PAGELYBIN' )) {
-		$host = 'Pagely';
-	} else if (DB_HOST == 'localhost:/tmp/mysql5.sock') {
-		$host = 'ICDSoft';
-	} else if (DB_HOST == 'mysqlv5') {
-		$host = 'NetworkSolutions';
-	} else if (strpos( DB_HOST, 'ipagemysql.com' ) !== false) {
-		$host = 'iPage';
-	} else if (strpos( DB_HOST, 'ipowermysql.com' ) !== false) {
-		$host = 'IPower';
-	} else if (strpos( DB_HOST, '.gridserver.com' ) !== false) {
-		$host = 'MediaTemple Grid';
-	} else if (strpos( DB_HOST, '.pair.com' ) !== false) {
-		$host = 'pair Networks';
-	} else if (strpos( DB_HOST, '.stabletransit.com' ) !== false) {
-		$host = 'Rackspace Cloud';
-	} else if (strpos( DB_HOST, '.sysfix.eu' ) !== false) {
-		$host = 'SysFix.eu Power Hosting';
-	} else if (strpos( $_SERVER['SERVER_NAME'], 'Flywheel' ) !== false) {
-		$host = 'Flywheel';
-	} else {
-		// Adding a general fallback for data gathering
-		$host = 'DBH: ' . DB_HOST . ', SRV: ' . $_SERVER['SERVER_NAME'];
-	}
+    if (defined( 'WPE_APIKEY' )) {
+        $host = 'WP Engine';
+    } else if (defined( 'PAGELYBIN' )) {
+        $host = 'Pagely';
+    } else if (DB_HOST == 'localhost:/tmp/mysql5.sock') {
+        $host = 'ICDSoft';
+    } else if (DB_HOST == 'mysqlv5') {
+        $host = 'NetworkSolutions';
+    } else if (strpos( DB_HOST, 'ipagemysql.com' ) !== false) {
+        $host = 'iPage';
+    } else if (strpos( DB_HOST, 'ipowermysql.com' ) !== false) {
+        $host = 'IPower';
+    } else if (strpos( DB_HOST, '.gridserver.com' ) !== false) {
+        $host = 'MediaTemple Grid';
+    } else if (strpos( DB_HOST, '.pair.com' ) !== false) {
+        $host = 'pair Networks';
+    } else if (strpos( DB_HOST, '.stabletransit.com' ) !== false) {
+        $host = 'Rackspace Cloud';
+    } else if (strpos( DB_HOST, '.sysfix.eu' ) !== false) {
+        $host = 'SysFix.eu Power Hosting';
+    } else if (strpos( $_SERVER['SERVER_NAME'], 'Flywheel' ) !== false) {
+        $host = 'Flywheel';
+    } else {
+        // Adding a general fallback for data gathering
+        $host = 'DBH: ' . DB_HOST . ', SRV: ' . $_SERVER['SERVER_NAME'];
+    }
 
-	return $host;
+    return $host;
 }
 
 
@@ -2707,22 +2730,22 @@ function um_get_host() {
  * @return int|string
  */
 function um_let_to_num( $v ) {
-	$l = substr( $v, -1 );
-	$ret = substr( $v, 0, -1 );
+    $l = substr( $v, -1 );
+    $ret = substr( $v, 0, -1 );
 
-	switch (strtoupper( $l )) {
-		case 'P': // fall-through
-		case 'T': // fall-through
-		case 'G': // fall-through
-		case 'M': // fall-through
-		case 'K': // fall-through
-			$ret *= 1024;
-			break;
-		default:
-			break;
-	}
+    switch (strtoupper( $l )) {
+        case 'P': // fall-through
+        case 'T': // fall-through
+        case 'G': // fall-through
+        case 'M': // fall-through
+        case 'K': // fall-through
+            $ret *= 1024;
+            break;
+        default:
+            break;
+    }
 
-	return $ret;
+    return $ret;
 }
 
 
@@ -2732,12 +2755,12 @@ function um_let_to_num( $v ) {
  * @return bool
  */
 function is_ultimatemember() {
-	global $post;
+    global $post;
 
-	if ( isset( $post->ID ) && in_array( $post->ID, UM()->config()->permalinks ) )
-		return true;
+    if ( isset( $post->ID ) && in_array( $post->ID, UM()->config()->permalinks ) )
+        return true;
 
-	return false;
+    return false;
 }
 
 
@@ -2745,7 +2768,7 @@ function is_ultimatemember() {
  * Maybe set empty time limit
  */
 function um_maybe_unset_time_limit() {
-	@set_time_limit( 0 );
+    @set_time_limit( 0 );
 }
 
 
@@ -2754,22 +2777,22 @@ function um_maybe_unset_time_limit() {
  * @Returns Boolean
 */
 if ( ! function_exists( 'um_is_profile_owner' ) ) {
-	/**
-	 * @param $user_id
-	 *
-	 * @return bool
-	 */
-	function um_is_profile_owner( $user_id = false ) {
-		if ( ! is_user_logged_in() ) {
-			return false;
-		}
+    /**
+     * @param $user_id
+     *
+     * @return bool
+     */
+    function um_is_profile_owner( $user_id = false ) {
+        if ( ! is_user_logged_in() ) {
+            return false;
+        }
 
-		if ( empty( $user_id ) ) {
-			$user_id = get_current_user_id();
-		}
+        if ( empty( $user_id ) ) {
+            $user_id = get_current_user_id();
+        }
 
-		return ( $user_id == um_profile_id() );
-	}
+        return ( $user_id == um_profile_id() );
+    }
 }
 
 
@@ -2788,16 +2811,16 @@ if ( ! function_exists( 'um_is_profile_owner' ) ) {
  */
 function um_is_amp( $check_theme_support = true ) {
 
-	$is_amp = false;
+    $is_amp = false;
 
-	if ( ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ||
-	     ( function_exists( 'is_better_amp' ) && is_better_amp() ) ) {
-		$is_amp = true;
-	}
+    if ( ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ||
+        ( function_exists( 'is_better_amp' ) && is_better_amp() ) ) {
+        $is_amp = true;
+    }
 
-	if ( $is_amp && $check_theme_support ) {
-		$is_amp = current_theme_supports( 'amp' );
-	}
+    if ( $is_amp && $check_theme_support ) {
+        $is_amp = current_theme_supports( 'amp' );
+    }
 
-	return apply_filters( 'um_is_amp', $is_amp );
+    return apply_filters( 'um_is_amp', $is_amp );
 }

--- a/includes/um-short-functions.php
+++ b/includes/um-short-functions.php
@@ -14,9 +14,9 @@
  * @return string
  */
 function um_trim_string( $s, $length = 20 ) {
-    $s = strlen( $s ) > $length ? substr( $s, 0, $length ) . "..." : $s;
+	$s = strlen( $s ) > $length ? substr( $s, 0, $length ) . "..." : $s;
 
-    return $s;
+	return $s;
 }
 
 
@@ -29,17 +29,17 @@ function um_trim_string( $s, $length = 20 ) {
  */
 function um_dynamic_login_page_redirect( $redirect_to = '' ) {
 
-    $uri = um_get_core_page( 'login' );
+	$uri = um_get_core_page( 'login' );
 
-    if (!$redirect_to) {
-        $redirect_to = UM()->permalinks()->get_current_url();
-    }
+	if (!$redirect_to) {
+		$redirect_to = UM()->permalinks()->get_current_url();
+	}
 
-    $redirect_key = urlencode_deep( $redirect_to );
+	$redirect_key = urlencode_deep( $redirect_to );
 
-    $uri = add_query_arg( 'redirect_to', $redirect_key, $uri );
+	$uri = add_query_arg( 'redirect_to', $redirect_key, $uri );
 
-    return $uri;
+	return $uri;
 }
 
 
@@ -50,15 +50,15 @@ function um_dynamic_login_page_redirect( $redirect_to = '' ) {
  */
 function um_is_session_started() {
 
-    if ( php_sapi_name() !== 'cli' ) {
-        if ( version_compare( phpversion(), '5.4.0', '>=' ) ) {
-            return session_status() === PHP_SESSION_ACTIVE ? true : false;
-        } else {
-            return session_id() === '' ? false : true;
-        }
-    }
+	if ( php_sapi_name() !== 'cli' ) {
+		if ( version_compare( phpversion(), '5.4.0', '>=' ) ) {
+			return session_status() === PHP_SESSION_ACTIVE ? true : false;
+		} else {
+			return session_id() === '' ? false : true;
+		}
+	}
 
-    return false;
+	return false;
 }
 
 /**
@@ -70,35 +70,35 @@ function um_is_session_started() {
  */
 function um_clean_user_basename( $value ) {
 
-    $raw_value = $value;
-    $value = str_replace( '.', ' ', $value );
-    $value = str_replace( '-', ' ', $value );
-    $value = str_replace( '+', ' ', $value );
+	$raw_value = $value;
+	$value = str_replace( '.', ' ', $value );
+	$value = str_replace( '-', ' ', $value );
+	$value = str_replace( '+', ' ', $value );
 
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_clean_user_basename_filter
-     * @description Change clean user basename
-     * @input_vars
-     * [{"var":"$basename","type":"string","desc":"User basename"},
-     * {"var":"$raw_basename","type":"string","desc":"RAW user basename"}]
-     * @change_log
-     * ["Since: 2.0"]
-     * @usage add_filter( 'um_clean_user_basename_filter', 'function_name', 10, 2 );
-     * @example
-     * <?php
-     * add_filter( 'um_clean_user_basename_filter', 'my_clean_user_basename', 10, 2 );
-     * function my_clean_user_basename( $basename, $raw_basename ) {
-     *     // your code here
-     *     return $basename;
-     * }
-     * ?>
-     */
-    $value = apply_filters( 'um_clean_user_basename_filter', $value, $raw_value );
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_clean_user_basename_filter
+	 * @description Change clean user basename
+	 * @input_vars
+	 * [{"var":"$basename","type":"string","desc":"User basename"},
+	 * {"var":"$raw_basename","type":"string","desc":"RAW user basename"}]
+	 * @change_log
+	 * ["Since: 2.0"]
+	 * @usage add_filter( 'um_clean_user_basename_filter', 'function_name', 10, 2 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_clean_user_basename_filter', 'my_clean_user_basename', 10, 2 );
+	 * function my_clean_user_basename( $basename, $raw_basename ) {
+	 *     // your code here
+	 *     return $basename;
+	 * }
+	 * ?>
+	 */
+	$value = apply_filters( 'um_clean_user_basename_filter', $value, $raw_value );
 
-    return $value;
+	return $value;
 }
 
 
@@ -109,76 +109,76 @@ function um_clean_user_basename( $value ) {
  */
 function um_replace_placeholders() {
 
-    $search = array(
-        '{display_name}',
-        '{first_name}',
-        '{last_name}',
-        '{gender}',
-        '{username}',
-        '{email}',
-        '{site_name}',
-        '{user_account_link}',
-    );
+	$search = array(
+		'{display_name}',
+		'{first_name}',
+		'{last_name}',
+		'{gender}',
+		'{username}',
+		'{email}',
+		'{site_name}',
+		'{user_account_link}',
+	);
 
 
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_template_tags_patterns_hook
-     * @description Extend UM placeholders
-     * @input_vars
-     * [{"var":"$placeholders","type":"array","desc":"UM Placeholders"}]
-     * @change_log
-     * ["Since: 2.0"]
-     * @usage add_filter( 'um_template_tags_patterns_hook', 'function_name', 10, 1 );
-     * @example
-     * <?php
-     * add_filter( 'um_template_tags_patterns_hook', 'my_template_tags_patterns', 10, 1 );
-     * function my_template_tags_patterns( $placeholders ) {
-     *     // your code here
-     *     $placeholders[] = '{my_custom_placeholder}';
-     *     return $placeholders;
-     * }
-     * ?>
-     */
-    $search = apply_filters( 'um_template_tags_patterns_hook', $search );
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_template_tags_patterns_hook
+	 * @description Extend UM placeholders
+	 * @input_vars
+	 * [{"var":"$placeholders","type":"array","desc":"UM Placeholders"}]
+	 * @change_log
+	 * ["Since: 2.0"]
+	 * @usage add_filter( 'um_template_tags_patterns_hook', 'function_name', 10, 1 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_template_tags_patterns_hook', 'my_template_tags_patterns', 10, 1 );
+	 * function my_template_tags_patterns( $placeholders ) {
+	 *     // your code here
+	 *     $placeholders[] = '{my_custom_placeholder}';
+	 *     return $placeholders;
+	 * }
+	 * ?>
+	 */
+	$search = apply_filters( 'um_template_tags_patterns_hook', $search );
 
-    $replace = array(
-        um_user( 'display_name' ),
-        um_user( 'first_name' ),
-        um_user( 'last_name' ),
-        um_user( 'gender' ),
-        um_user( 'user_login' ),
-        um_user( 'user_email' ),
-        UM()->options()->get( 'site_name' ),
-        um_get_core_page( 'account' ),
-    );
+	$replace = array(
+		um_user( 'display_name' ),
+		um_user( 'first_name' ),
+		um_user( 'last_name' ),
+		um_user( 'gender' ),
+		um_user( 'user_login' ),
+		um_user( 'user_email' ),
+		UM()->options()->get( 'site_name' ),
+		um_get_core_page( 'account' ),
+	);
 
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_template_tags_replaces_hook
-     * @description Extend UM replace placeholders
-     * @input_vars
-     * [{"var":"$replace_placeholders","type":"array","desc":"UM Replace Placeholders"}]
-     * @change_log
-     * ["Since: 2.0"]
-     * @usage add_filter( 'um_template_tags_replaces_hook', 'function_name', 10, 1 );
-     * @example
-     * <?php
-     * add_filter( 'um_template_tags_replaces_hook', 'my_template_tags_replaces', 10, 1 );
-     * function my_template_tags_replaces( $replace_placeholders ) {
-     *     // your code here
-     *     $replace_placeholders[] = 'my_replace_value';
-     *     return $replace_placeholders;
-     * }
-     * ?>
-     */
-    $replace = apply_filters( 'um_template_tags_replaces_hook', $replace );
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_template_tags_replaces_hook
+	 * @description Extend UM replace placeholders
+	 * @input_vars
+	 * [{"var":"$replace_placeholders","type":"array","desc":"UM Replace Placeholders"}]
+	 * @change_log
+	 * ["Since: 2.0"]
+	 * @usage add_filter( 'um_template_tags_replaces_hook', 'function_name', 10, 1 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_template_tags_replaces_hook', 'my_template_tags_replaces', 10, 1 );
+	 * function my_template_tags_replaces( $replace_placeholders ) {
+	 *     // your code here
+	 *     $replace_placeholders[] = 'my_replace_value';
+	 *     return $replace_placeholders;
+	 * }
+	 * ?>
+	 */
+	$replace = apply_filters( 'um_template_tags_replaces_hook', $replace );
 
-    return array_combine( $search, $replace );
+	return array_combine( $search, $replace );
 }
 
 
@@ -192,32 +192,32 @@ function um_replace_placeholders() {
  * @return mixed|string
  */
 function um_convert_tags( $content, $args = array(), $with_kses = true ) {
-    $placeholders = um_replace_placeholders();
+	$placeholders = um_replace_placeholders();
 
-    $content = str_replace( array_keys( $placeholders ), array_values( $placeholders ), $content );
-    if ( $with_kses ) {
-        $content = wp_kses_decode_entities( $content );
-    }
+	$content = str_replace( array_keys( $placeholders ), array_values( $placeholders ), $content );
+	if ( $with_kses ) {
+		$content = wp_kses_decode_entities( $content );
+	}
 
-    if ( isset( $args['tags'] ) && isset( $args['tags_replace'] ) ) {
-        $content = str_replace( $args['tags'], $args['tags_replace'], $content );
-    }
+	if ( isset( $args['tags'] ) && isset( $args['tags_replace'] ) ) {
+		$content = str_replace( $args['tags'], $args['tags_replace'], $content );
+	}
 
-    $regex = '~\{(usermeta:[^}]*)\}~';
-    preg_match_all( $regex, $content, $matches );
+	$regex = '~\{(usermeta:[^}]*)\}~';
+	preg_match_all( $regex, $content, $matches );
 
-    // Support for all usermeta keys
-    if ( ! empty( $matches[1] ) && is_array( $matches[1] ) ) {
-        foreach ( $matches[1] as $match ) {
-            $key = str_replace( 'usermeta:', '', $match );
-            $value = um_user( $key );
-            if ( is_array( $value ) ) {
-                $value = implode( ', ', $value );
-            }
-            $content = str_replace( '{' . $match . '}', apply_filters( 'um_convert_tags', $value, $key ), $content );
-        }
-    }
-    return $content;
+	// Support for all usermeta keys
+	if ( ! empty( $matches[1] ) && is_array( $matches[1] ) ) {
+		foreach ( $matches[1] as $match ) {
+			$key = str_replace( 'usermeta:', '', $match );
+			$value = um_user( $key );
+			if ( is_array( $value ) ) {
+				$value = implode( ', ', $value );
+			}
+			$content = str_replace( '{' . $match . '}', apply_filters( 'um_convert_tags', $value, $key ), $content );
+		}
+	}
+	return $content;
 }
 
 
@@ -229,8 +229,8 @@ function um_convert_tags( $content, $args = array(), $with_kses = true ) {
  * @return array
  */
 function account_activation_link_tags_patterns( $placeholders ) {
-    $placeholders[] = '{account_activation_link}';
-    return $placeholders;
+	$placeholders[] = '{account_activation_link}';
+	return $placeholders;
 }
 
 /**
@@ -241,8 +241,8 @@ function account_activation_link_tags_patterns( $placeholders ) {
  * @return array
  */
 function account_activation_link_tags_replaces( $replace_placeholders ) {
-    $replace_placeholders[] = um_user( 'account_activation_link' );
-    return $replace_placeholders;
+	$replace_placeholders[] = um_user( 'account_activation_link' );
+	return $replace_placeholders;
 }
 
 
@@ -265,39 +265,39 @@ function account_activation_link_tags_replaces( $replace_placeholders ) {
  * ?>
  */
 function um_user_ip() {
-    $ip = '127.0.0.1';
+	$ip = '127.0.0.1';
 
-    if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ) {
-        //check ip from share internet
-        $ip = $_SERVER['HTTP_CLIENT_IP'];
-    } else if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-        //to check ip is pass from proxy
-        $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
-    } else if ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
-        $ip = $_SERVER['REMOTE_ADDR'];
-    }
+	if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ) {
+		//check ip from share internet
+		$ip = $_SERVER['HTTP_CLIENT_IP'];
+	} else if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+		//to check ip is pass from proxy
+		$ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+	} else if ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+		$ip = $_SERVER['REMOTE_ADDR'];
+	}
 
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_user_ip
-     * @description Change User IP
-     * @input_vars
-     * [{"var":"$ip","type":"string","desc":"User IP"}]
-     * @change_log
-     * ["Since: 2.0"]
-     * @usage add_filter( 'um_user_ip', 'function_name', 10, 1 );
-     * @example
-     * <?php
-     * add_filter( 'um_user_ip', 'my_user_ip', 10, 1 );
-     * function my_user_ip( $ip ) {
-     *     // your code here
-     *     return $ip;
-     * }
-     * ?>
-     */
-    return apply_filters( 'um_user_ip', $ip );
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_user_ip
+	 * @description Change User IP
+	 * @input_vars
+	 * [{"var":"$ip","type":"string","desc":"User IP"}]
+	 * @change_log
+	 * ["Since: 2.0"]
+	 * @usage add_filter( 'um_user_ip', 'function_name', 10, 1 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_user_ip', 'my_user_ip', 10, 1 );
+	 * function my_user_ip( $ip ) {
+	 *     // your code here
+	 *     return $ip;
+	 * }
+	 * ?>
+	 */
+	return apply_filters( 'um_user_ip', $ip );
 }
 
 
@@ -310,290 +310,290 @@ function um_user_ip() {
  */
 function um_field_conditions_are_met( $data ) {
 
-    if ( ! isset( $data['conditions'] ) ) {
-        return true;
-    }
+	if ( ! isset( $data['conditions'] ) ) {
+		return true;
+	}
 
-    $state = ( isset( $data['conditional_action'] ) && $data['conditional_action'] == 'show' ) ? 1 : 0;
+	$state = ( isset( $data['conditional_action'] ) && $data['conditional_action'] == 'show' ) ? 1 : 0;
 
-    $first_group = 0;
-    $state_array = array();
-    $count = count( $state_array );
-    foreach ( $data['conditions'] as $k => $arr ) {
+	$first_group = 0;
+	$state_array = array();
+	$count = count( $state_array );
+	foreach ( $data['conditions'] as $k => $arr ) {
 
-        $val = $arr[3];
-        $op = $arr[2];
+		$val = $arr[3];
+		$op = $arr[2];
 
-        if ( strstr( $arr[1], 'role_' ) ) {
-            $arr[1] = 'role';
-        }
+		if ( strstr( $arr[1], 'role_' ) ) {
+			$arr[1] = 'role';
+		}
 
-        $field = um_profile( $arr[1] );
-
-
-        if ( ! isset( $arr[5] ) || $arr[5] != $first_group ) {
+		$field = um_profile( $arr[1] );
 
 
-            if ( $arr[0] == 'show' ) {
-
-                switch ($op) {
-                    case 'equals to':
-
-                        $field = maybe_unserialize( $field );
-
-                        if (is_array( $field ))
-                            $state = in_array( $val, $field ) ? 'show' : 'hide';
-                        else
-                            $state = ( $field == $val ) ? 'show' : 'hide';
-
-                        break;
-                    case 'not equals':
-
-                        $field = maybe_unserialize( $field );
-
-                        if (is_array( $field ))
-                            $state = !in_array( $val, $field ) ? 'show' : 'hide';
-                        else
-                            $state = ( $field != $val ) ? 'show' : 'hide';
-
-                        break;
-                    case 'empty':
-
-                        $state = ( !$field ) ? 'show' : 'hide';
-
-                        break;
-                    case 'not empty':
-
-                        $state = ( $field ) ? 'show' : 'hide';
-
-                        break;
-                    case 'greater than':
-                        if ($field > $val) {
-                            $state = 'show';
-                        } else {
-                            $state = 'hide';
-                        }
-                        break;
-                    case 'less than':
-                        if ($field < $val) {
-                            $state = 'show';
-                        } else {
-                            $state = 'hide';
-                        }
-                        break;
-                    case 'contains':
-                        if (strstr( $field, $val )) {
-                            $state = 'show';
-                        } else {
-                            $state = 'hide';
-                        }
-                        break;
-                }
-            } elseif ( $arr[0] == 'hide' ) {
-
-                switch ( $op ) {
-                    case 'equals to':
-
-                        $field = maybe_unserialize( $field );
-
-                        if ( is_array( $field ) ) {
-                            $state = in_array( $val, $field ) ? 'hide' : 'show';
-                        } else {
-                            $state = ( $field == $val ) ? 'hide' : 'show';
-                        }
-
-                        break;
-                    case 'not equals':
-
-                        $field = maybe_unserialize( $field );
-
-                        if ( is_array( $field ) ) {
-                            $state = ! in_array( $val, $field ) ? 'hide' : 'show';
-                        } else {
-                            $state = ( $field != $val ) ? 'hide' : 'show';
-                        }
-
-                        break;
-                    case 'empty':
-
-                        $state = ( ! $field ) ? 'hide' : 'show';
-
-                        break;
-                    case 'not empty':
-
-                        $state = ( $field ) ? 'hide' : 'show';
-
-                        break;
-                    case 'greater than':
-                        if ( $field <= $val ) {
-                            $state = 'hide';
-                        } else {
-                            $state = 'show';
-                        }
-                        break;
-                    case 'less than':
-                        if ( $field >= $val ) {
-                            $state = 'hide';
-                        } else {
-                            $state = 'show';
-                        }
-                        break;
-                    case 'contains':
-                        if ( strstr( $field, $val ) ) {
-                            $state = 'hide';
-                        } else {
-                            $state = 'show';
-                        }
-                        break;
-                }
-            }
-            $first_group++;
-            array_push( $state_array, $state );
-        } else {
-
-            if ( $arr[0] == 'show' ) {
-
-                switch ( $op ) {
-                    case 'equals to':
-                        $field = maybe_unserialize( $field );
-
-                        if ( is_array( $field ) ) {
-                            $state = in_array( $val, $field ) ? 'show' : 'not_show';
-                        } else {
-                            $state = ( $field == $val ) ? 'show' : 'not_show';
-                        }
-
-                        break;
-                    case 'not equals':
-                        $field = maybe_unserialize( $field );
-
-                        if ( is_array( $field ) ) {
-                            $state = ! in_array( $val, $field ) ? 'show' : 'not_show';
-                        } else {
-                            $state = ( $field != $val ) ? 'show' : 'not_show';
-                        }
-
-                        break;
-                    case 'empty':
-
-                        $state = ( ! $field ) ? 'show' : 'not_show';
-
-                        break;
-                    case 'not empty':
-
-                        $state = ( $field ) ? 'show': 'not_show';
-
-                        break;
-                    case 'greater than':
-                        if ( $field > $val ) {
-                            $state = 'show';
-                        } else {
-                            $state = 'not_show';
-                        }
-                        break;
-                    case 'less than':
-                        if ( $field < $val ) {
-                            $state = 'show';
-                        } else {
-                            $state = 'not_show';
-                        }
-                        break;
-                    case 'contains':
-                        if ( strstr( $field, $val ) ) {
-                            $state = 'show';
-                        } else {
-                            $state = 'not_show';
-                        }
-                        break;
-                }
-            } elseif ( $arr[0] == 'hide' ) {
-
-                switch ( $op ) {
-                    case 'equals to':
-                        $field = maybe_unserialize( $field );
-
-                        if ( is_array( $field ) ) {
-                            $state = in_array( $val, $field ) ? 'hide' : 'not_hide';
-                        } else {
-                            $state = ( $field == $val ) ? 'hide' : 'not_hide';
-                        }
-
-                        break;
-                    case 'not equals':
-
-                        $field = maybe_unserialize( $field );
-
-                        if ( is_array( $field ) ) {
-                            $state = ! in_array( $val, $field ) ? 'hide' : 'not_hide';
-                        } else {
-                            $state = ( $field != $val ) ? 'hide' : 'not_hide';
-                        }
-
-                        break;
-                    case 'empty':
-
-                        $state = ( ! $field ) ? 'hide' : 'not_hide';
-
-                        break;
-                    case 'not empty':
-
-                        $state = ( $field ) ? 'hide' : 'not_hide';
-
-                        break;
-                    case 'greater than':
-                        if ( $field <= $val ) {
-                            $state = 'hide';
-                        } else {
-                            $state = 'not_hide';
-                        }
-                        break;
-                    case 'less than':
-                        if ( $field >= $val ) {
-                            $state = 'hide';
-                        } else {
-                            $state = 'not_hide';
-                        }
-                        break;
-                    case 'contains':
-                        if ( strstr( $field, $val ) ) {
-                            $state = 'hide';
-                        } else {
-                            $state = 'not_hide';
-                        }
-                        break;
-                }
-            }
-            if ( isset( $state_array[ $count ] ) ) {
-                if ( $state_array[ $count ] == 'show' || $state_array[ $count ] == 'not_hide' ) {
-                    if ( $state == 'show' || $state == 'not_hide' ) {
-                        $state_array[ $count ] = 'show';
-                    } else {
-                        $state_array[ $count ] = 'hide';
-                    }
-                } else {
-                    if ( $state == 'hide' || $state == 'not_show' ) {
-                        $state_array[ $count ] = 'hide';
-                    } else {
-                        $state_array[ $count ] = 'hide';
-                    }
-                }
-            } else {
-                if ( $state == 'show' || $state == 'not_hide' ) {
-                    $state_array[ $count ] = 'show';
-                } else {
-                    $state_array[ $count ] = 'hide';
-                }
-            }
-        }
+		if ( ! isset( $arr[5] ) || $arr[5] != $first_group ) {
 
 
-    }
-    $result = array_unique( $state_array );
-    if ( ! in_array( 'show', $result ) ) {
-        return $state = false;
-    } else {
-        return $state = true;
-    }
+			if ( $arr[0] == 'show' ) {
+
+				switch ($op) {
+					case 'equals to':
+
+						$field = maybe_unserialize( $field );
+
+						if (is_array( $field ))
+							$state = in_array( $val, $field ) ? 'show' : 'hide';
+						else
+							$state = ( $field == $val ) ? 'show' : 'hide';
+
+						break;
+					case 'not equals':
+
+						$field = maybe_unserialize( $field );
+
+						if (is_array( $field ))
+							$state = !in_array( $val, $field ) ? 'show' : 'hide';
+						else
+							$state = ( $field != $val ) ? 'show' : 'hide';
+
+						break;
+					case 'empty':
+
+						$state = ( !$field ) ? 'show' : 'hide';
+
+						break;
+					case 'not empty':
+
+						$state = ( $field ) ? 'show' : 'hide';
+
+						break;
+					case 'greater than':
+						if ($field > $val) {
+							$state = 'show';
+						} else {
+							$state = 'hide';
+						}
+						break;
+					case 'less than':
+						if ($field < $val) {
+							$state = 'show';
+						} else {
+							$state = 'hide';
+						}
+						break;
+					case 'contains':
+						if (strstr( $field, $val )) {
+							$state = 'show';
+						} else {
+							$state = 'hide';
+						}
+						break;
+				}
+			} elseif ( $arr[0] == 'hide' ) {
+
+				switch ( $op ) {
+					case 'equals to':
+
+						$field = maybe_unserialize( $field );
+
+						if ( is_array( $field ) ) {
+							$state = in_array( $val, $field ) ? 'hide' : 'show';
+						} else {
+							$state = ( $field == $val ) ? 'hide' : 'show';
+						}
+
+						break;
+					case 'not equals':
+
+						$field = maybe_unserialize( $field );
+
+						if ( is_array( $field ) ) {
+							$state = ! in_array( $val, $field ) ? 'hide' : 'show';
+						} else {
+							$state = ( $field != $val ) ? 'hide' : 'show';
+						}
+
+						break;
+					case 'empty':
+
+						$state = ( ! $field ) ? 'hide' : 'show';
+
+						break;
+					case 'not empty':
+
+						$state = ( $field ) ? 'hide' : 'show';
+
+						break;
+					case 'greater than':
+						if ( $field <= $val ) {
+							$state = 'hide';
+						} else {
+							$state = 'show';
+						}
+						break;
+					case 'less than':
+						if ( $field >= $val ) {
+							$state = 'hide';
+						} else {
+							$state = 'show';
+						}
+						break;
+					case 'contains':
+						if ( strstr( $field, $val ) ) {
+							$state = 'hide';
+						} else {
+							$state = 'show';
+						}
+						break;
+				}
+			}
+			$first_group++;
+			array_push( $state_array, $state );
+		} else {
+
+			if ( $arr[0] == 'show' ) {
+
+				switch ( $op ) {
+					case 'equals to':
+						$field = maybe_unserialize( $field );
+
+						if ( is_array( $field ) ) {
+							$state = in_array( $val, $field ) ? 'show' : 'not_show';
+						} else {
+							$state = ( $field == $val ) ? 'show' : 'not_show';
+						}
+
+						break;
+					case 'not equals':
+						$field = maybe_unserialize( $field );
+
+						if ( is_array( $field ) ) {
+							$state = ! in_array( $val, $field ) ? 'show' : 'not_show';
+						} else {
+							$state = ( $field != $val ) ? 'show' : 'not_show';
+						}
+
+						break;
+					case 'empty':
+
+						$state = ( ! $field ) ? 'show' : 'not_show';
+
+						break;
+					case 'not empty':
+
+						$state = ( $field ) ? 'show': 'not_show';
+
+						break;
+					case 'greater than':
+						if ( $field > $val ) {
+							$state = 'show';
+						} else {
+							$state = 'not_show';
+						}
+						break;
+					case 'less than':
+						if ( $field < $val ) {
+							$state = 'show';
+						} else {
+							$state = 'not_show';
+						}
+						break;
+					case 'contains':
+						if ( strstr( $field, $val ) ) {
+							$state = 'show';
+						} else {
+							$state = 'not_show';
+						}
+						break;
+				}
+			} elseif ( $arr[0] == 'hide' ) {
+
+				switch ( $op ) {
+					case 'equals to':
+						$field = maybe_unserialize( $field );
+
+						if ( is_array( $field ) ) {
+							$state = in_array( $val, $field ) ? 'hide' : 'not_hide';
+						} else {
+							$state = ( $field == $val ) ? 'hide' : 'not_hide';
+						}
+
+						break;
+					case 'not equals':
+
+						$field = maybe_unserialize( $field );
+
+						if ( is_array( $field ) ) {
+							$state = ! in_array( $val, $field ) ? 'hide' : 'not_hide';
+						} else {
+							$state = ( $field != $val ) ? 'hide' : 'not_hide';
+						}
+
+						break;
+					case 'empty':
+
+						$state = ( ! $field ) ? 'hide' : 'not_hide';
+
+						break;
+					case 'not empty':
+
+						$state = ( $field ) ? 'hide' : 'not_hide';
+
+						break;
+					case 'greater than':
+						if ( $field <= $val ) {
+							$state = 'hide';
+						} else {
+							$state = 'not_hide';
+						}
+						break;
+					case 'less than':
+						if ( $field >= $val ) {
+							$state = 'hide';
+						} else {
+							$state = 'not_hide';
+						}
+						break;
+					case 'contains':
+						if ( strstr( $field, $val ) ) {
+							$state = 'hide';
+						} else {
+							$state = 'not_hide';
+						}
+						break;
+				}
+			}
+			if ( isset( $state_array[ $count ] ) ) {
+				if ( $state_array[ $count ] == 'show' || $state_array[ $count ] == 'not_hide' ) {
+					if ( $state == 'show' || $state == 'not_hide' ) {
+						$state_array[ $count ] = 'show';
+					} else {
+						$state_array[ $count ] = 'hide';
+					}
+				} else {
+					if ( $state == 'hide' || $state == 'not_show' ) {
+						$state_array[ $count ] = 'hide';
+					} else {
+						$state_array[ $count ] = 'hide';
+					}
+				}
+			} else {
+				if ( $state == 'show' || $state == 'not_hide' ) {
+					$state_array[ $count ] = 'show';
+				} else {
+					$state_array[ $count ] = 'hide';
+				}
+			}
+		}
+
+
+	}
+	$result = array_unique( $state_array );
+	if ( ! in_array( 'show', $result ) ) {
+		return $state = false;
+	} else {
+		return $state = true;
+	}
 }
 
 
@@ -604,8 +604,8 @@ function um_field_conditions_are_met( $data ) {
  * @param string $is_my_profile
  */
 function um_redirect_home( $requested_user_id = '', $is_my_profile = '' ) {
-    $url = apply_filters( 'um_redirect_home_custom_url', home_url(), $requested_user_id, $is_my_profile );
-    exit( wp_redirect( $url ) );
+	$url = apply_filters( 'um_redirect_home_custom_url', home_url(), $requested_user_id, $is_my_profile );
+	exit( wp_redirect( $url ) );
 }
 
 
@@ -614,29 +614,29 @@ function um_redirect_home( $requested_user_id = '', $is_my_profile = '' ) {
  * @param $url
  */
 function um_js_redirect( $url ) {
-    if ( headers_sent() || empty( $url ) ) {
-        //for blank redirects
-        if ( '' == $url ) {
-            $url = set_url_scheme( '//' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"] );
-        }
+	if ( headers_sent() || empty( $url ) ) {
+		//for blank redirects
+		if ( '' == $url ) {
+			$url = set_url_scheme( '//' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"] );
+		}
 
-        register_shutdown_function( function( $url ) {
-            echo '<script data-cfasync="false" type="text/javascript">window.location = "' . esc_js( $url ) . '"</script>';
-        }, $url );
+		register_shutdown_function( function( $url ) {
+			echo '<script data-cfasync="false" type="text/javascript">window.location = "' . esc_js( $url ) . '"</script>';
+		}, $url );
 
-        if ( 1 < ob_get_level() ) {
-            while ( ob_get_level() > 1 ) {
-                ob_end_clean();
-            }
-        } ?>
-        <script data-cfasync='false' type="text/javascript">
-            window.location = '<?php echo esc_js( $url ); ?>';
-        </script>
-        <?php exit;
-    } else {
-        wp_redirect( $url );
-    }
-    exit;
+		if ( 1 < ob_get_level() ) {
+			while ( ob_get_level() > 1 ) {
+				ob_end_clean();
+			}
+		} ?>
+		<script data-cfasync='false' type="text/javascript">
+			window.location = '<?php echo esc_js( $url ); ?>';
+		</script>
+		<?php exit;
+	} else {
+		wp_redirect( $url );
+	}
+	exit;
 }
 
 
@@ -649,23 +649,23 @@ function um_js_redirect( $url ) {
  * @return string
  */
 function um_get_snippet( $str, $wordCount = 10 ) {
-    if (str_word_count( $str, 0, "éèàôù" ) > $wordCount) {
-        $str = implode(
-            '',
-            array_slice(
-                preg_split(
-                    '/([\s,\.;\?\!]+)/',
-                    $str,
-                    $wordCount * 2 + 1,
-                    PREG_SPLIT_DELIM_CAPTURE
-                ),
-                0,
-                $wordCount * 2 - 1
-            )
-        );
-    }
+	if (str_word_count( $str, 0, "éèàôù" ) > $wordCount) {
+		$str = implode(
+			'',
+			array_slice(
+				preg_split(
+					'/([\s,\.;\?\!]+)/',
+					$str,
+					$wordCount * 2 + 1,
+					PREG_SPLIT_DELIM_CAPTURE
+				),
+				0,
+				$wordCount * 2 - 1
+			)
+		);
+	}
 
-    return $str;
+	return $str;
 }
 
 
@@ -677,151 +677,151 @@ function um_get_snippet( $str, $wordCount = 10 ) {
  * @since  2.1.4
  */
 function um_user_submitted_registration_formatted( $style = false ) {
-    $output = null;
+	$output = null;
 
-    $submitted_data = um_user( 'submitted' );
+	$submitted_data = um_user( 'submitted' );
 
-    if ( $style ) {
-        $output .= '<div class="um-admin-infobox">';
-    }
+	if ( $style ) {
+		$output .= '<div class="um-admin-infobox">';
+	}
 
-    // Timestamp
-    $output .= um_user_submited_display( 'timestamp', __( 'Date Submitted', 'ultimate-member' ) );
-    $output .= um_user_submited_display( 'form_id', __( 'Form', 'ultimate-member' ), $submitted_data );
+	// Timestamp
+	$output .= um_user_submited_display( 'timestamp', __( 'Date Submitted', 'ultimate-member' ) );
+	$output .= um_user_submited_display( 'form_id', __( 'Form', 'ultimate-member' ), $submitted_data );
 
-    if ( isset( $submitted_data ) && is_array( $submitted_data ) ) {
+	if ( isset( $submitted_data ) && is_array( $submitted_data ) ) {
 
-        if ( isset( $submitted_data['form_id'] ) ) {
-            $fields = UM()->query()->get_attr( 'custom_fields', $submitted_data['form_id'] );
-        }
+		if ( isset( $submitted_data['form_id'] ) ) {
+			$fields = UM()->query()->get_attr( 'custom_fields', $submitted_data['form_id'] );
+		}
 
-        if ( isset( $fields ) ) {
+		if ( isset( $fields ) ) {
 
-            $fields['form_id'] = array( 'title' => __( 'Form', 'ultimate-member' ) );
+			$fields['form_id'] = array( 'title' => __( 'Form', 'ultimate-member' ) );
 
-            $rows = array();
+			$rows = array();
 
-            UM()->fields()->get_fields = $fields;
+			UM()->fields()->get_fields = $fields;
 
-            foreach ( $fields as $key => $array ) {
-                if ( isset( $array['type'] ) && $array['type'] == 'row' ) {
-                    $rows[ $key ] = $array;
-                    unset( UM()->fields()->get_fields[ $key ] ); // not needed now
-                }
-            }
+			foreach ( $fields as $key => $array ) {
+				if ( isset( $array['type'] ) && $array['type'] == 'row' ) {
+					$rows[ $key ] = $array;
+					unset( UM()->fields()->get_fields[ $key ] ); // not needed now
+				}
+			}
 
-            if ( empty( $rows ) ) {
-                $rows = array(
-                    '_um_row_1' => array(
-                        'type'      => 'row',
-                        'id'        => '_um_row_1',
-                        'sub_rows'  => 1,
-                        'cols'      => 1
-                    ),
-                );
-            }
+			if ( empty( $rows ) ) {
+				$rows = array(
+					'_um_row_1' => array(
+						'type'      => 'row',
+						'id'        => '_um_row_1',
+						'sub_rows'  => 1,
+						'cols'      => 1
+					),
+				);
+			}
 
-            foreach ( $rows as $row_id => $row_array ) {
+			foreach ( $rows as $row_id => $row_array ) {
 
-                $row_fields = UM()->fields()->get_fields_by_row( $row_id );
+				$row_fields = UM()->fields()->get_fields_by_row( $row_id );
 
-                if ( $row_fields ) {
+				if ( $row_fields ) {
 
-                    $output .= UM()->fields()->new_row_output( $row_id, $row_array );
+					$output .= UM()->fields()->new_row_output( $row_id, $row_array );
 
-                    $sub_rows = ( isset( $row_array['sub_rows'] ) ) ? $row_array['sub_rows'] : 1;
-                    for ( $c = 0; $c < $sub_rows; $c++ ) {
+					$sub_rows = ( isset( $row_array['sub_rows'] ) ) ? $row_array['sub_rows'] : 1;
+					for ( $c = 0; $c < $sub_rows; $c++ ) {
 
-                        // cols
-                        $cols = ( isset( $row_array['cols'] ) ) ? $row_array['cols'] : 1;
-                        if ( strstr( $cols, ':' ) ) {
-                            $col_split = explode( ':', $cols );
-                        } else {
-                            $col_split = array( $cols );
-                        }
-                        $cols_num = $col_split[ $c ];
+						// cols
+						$cols = ( isset( $row_array['cols'] ) ) ? $row_array['cols'] : 1;
+						if ( strstr( $cols, ':' ) ) {
+							$col_split = explode( ':', $cols );
+						} else {
+							$col_split = array( $cols );
+						}
+						$cols_num = $col_split[ $c ];
 
-                        // sub row fields
-                        $subrow_fields = null;
-                        $subrow_fields = UM()->fields()->get_fields_in_subrow( $row_fields, $c );
+						// sub row fields
+						$subrow_fields = null;
+						$subrow_fields = UM()->fields()->get_fields_in_subrow( $row_fields, $c );
 
-                        if ( is_array( $subrow_fields ) ) {
+						if ( is_array( $subrow_fields ) ) {
 
-                            if ( isset( $subrow_fields['form_id'] ) ) {
-                                unset( $subrow_fields['form_id'] );
-                            }
+							if ( isset( $subrow_fields['form_id'] ) ) {
+								unset( $subrow_fields['form_id'] );
+							}
 
-                            $subrow_fields = UM()->fields()->array_sort_by_column( $subrow_fields, 'position' );
+							$subrow_fields = UM()->fields()->array_sort_by_column( $subrow_fields, 'position' );
 
-                            if ( $cols_num == 1 ) {
+							if ( $cols_num == 1 ) {
 
-                                $col1_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 1 );
-                                if ( $col1_fields ) {
-                                    foreach ( $col1_fields as $key => $data ) {
-                                        $output .= um_user_submited_display( $key, $data['title'] );
-                                    }
-                                }
+								$col1_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 1 );
+								if ( $col1_fields ) {
+									foreach ( $col1_fields as $key => $data ) {
+										$output .= um_user_submited_display( $key, $data['title'] );
+									}
+								}
 
-                            } elseif ( $cols_num == 2 ) {
+							} elseif ( $cols_num == 2 ) {
 
-                                $col1_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 1 );
-                                if ( $col1_fields ) {
-                                    foreach ( $col1_fields as $key => $data ) {
-                                        $output .= um_user_submited_display( $key, $data['title'] );
-                                    }
-                                }
+								$col1_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 1 );
+								if ( $col1_fields ) {
+									foreach ( $col1_fields as $key => $data ) {
+										$output .= um_user_submited_display( $key, $data['title'] );
+									}
+								}
 
-                                $col2_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 2 );
-                                if ( $col2_fields ) {
-                                    foreach ( $col2_fields as $key => $data ) {
-                                        $output .= um_user_submited_display( $key, $data['title'] );
-                                    }
-                                }
+								$col2_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 2 );
+								if ( $col2_fields ) {
+									foreach ( $col2_fields as $key => $data ) {
+										$output .= um_user_submited_display( $key, $data['title'] );
+									}
+								}
 
-                            } else {
+							} else {
 
-                                $col1_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 1 );
-                                if ( $col1_fields ) {
-                                    foreach ( $col1_fields as $key => $data ) {
-                                        $output .= um_user_submited_display( $key, $data['title'] );
-                                    }
-                                }
+								$col1_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 1 );
+								if ( $col1_fields ) {
+									foreach ( $col1_fields as $key => $data ) {
+										$output .= um_user_submited_display( $key, $data['title'] );
+									}
+								}
 
-                                $col2_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 2 );
-                                if ( $col2_fields ) {
-                                    foreach ( $col2_fields as $key => $data ) {
-                                        $output .= um_user_submited_display( $key, $data['title'] );
-                                    }
-                                }
+								$col2_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 2 );
+								if ( $col2_fields ) {
+									foreach ( $col2_fields as $key => $data ) {
+										$output .= um_user_submited_display( $key, $data['title'] );
+									}
+								}
 
-                                $col3_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 3 );
-                                if ( $col3_fields ) {
-                                    foreach ( $col3_fields as $key => $data ) {
-                                        $output .= um_user_submited_display( $key, $data['title'] );
-                                    }
-                                }
+								$col3_fields = UM()->fields()->get_fields_in_column( $subrow_fields, 3 );
+								if ( $col3_fields ) {
+									foreach ( $col3_fields as $key => $data ) {
+										$output .= um_user_submited_display( $key, $data['title'] );
+									}
+								}
 
-                            }
+							}
 
-                        }
+						}
 
-                    }
+					}
 
-                }
-
-
-            } // endfor
-
-        }
-    }
+				}
 
 
-    if ( $style ) {
-        $output .= '</div>';
-    }
+			} // endfor
+
+		}
+	}
 
 
-    return $output;
+	if ( $style ) {
+		$output .= '</div>';
+	}
+
+
+	return $output;
 
 }
 
@@ -837,71 +837,71 @@ function um_user_submitted_registration_formatted( $style = false ) {
  * @since  2.1.4
  */
 function um_user_submited_display( $k, $title, $data = array(), $style = true ) {
-    $output = '';
+	$output = '';
 
-    if ( 'form_id' == $k && isset( $data['form_id'] ) && ! empty( $data['form_id'] ) ) {
-        $v = sprintf( __( '%s - Form ID#: %s', 'ultimate-member' ), get_the_title( $data['form_id'] ), $data['form_id'] );
-    } else {
-        $v = um_user( $k );
-    }
+	if ( 'form_id' == $k && isset( $data['form_id'] ) && ! empty( $data['form_id'] ) ) {
+		$v = sprintf( __( '%s - Form ID#: %s', 'ultimate-member' ), get_the_title( $data['form_id'] ), $data['form_id'] );
+	} else {
+		$v = um_user( $k );
+	}
 
-    if ( strstr( $k, 'user_pass' ) || in_array( $k, array( 'g-recaptcha-response', 'request', '_wpnonce', '_wp_http_referer' ) ) ) {
-        return '';
-    }
+	if ( strstr( $k, 'user_pass' ) || in_array( $k, array( 'g-recaptcha-response', 'request', '_wpnonce', '_wp_http_referer' ) ) ) {
+		return '';
+	}
 
-    $fields_without_metakey = UM()->builtin()->get_fields_without_metakey();
-    $type = UM()->fields()->get_field_type( $k );
-    if ( in_array( $type, $fields_without_metakey ) ) {
-        return '';
-    }
+	$fields_without_metakey = UM()->builtin()->get_fields_without_metakey();
+	$type = UM()->fields()->get_field_type( $k );
+	if ( in_array( $type, $fields_without_metakey ) ) {
+		return '';
+	}
 
-    if ( ! $v ) {
-        if ( $style ) {
-            return "<p><label>$title: </label><span>" . __( '(empty)', 'ultimate-member' ) ."</span></p>";
-        } else {
-            return '';
-        }
-    }
+	if ( ! $v ) {
+		if ( $style ) {
+			return "<p><label>$title: </label><span>" . __( '(empty)', 'ultimate-member' ) ."</span></p>";
+		} else {
+			return '';
+		}
+	}
 
-    if ( $type == 'image' || $type == 'file' ) {
-        $file = basename( $v );
+	if ( $type == 'image' || $type == 'file' ) {
+		$file = basename( $v );
 
-        $filedata = get_user_meta( um_user( 'ID' ), $k . "_metadata", true );
+		$filedata = get_user_meta( um_user( 'ID' ), $k . "_metadata", true );
 
-        $baseurl = UM()->uploader()->get_upload_base_url();
-        if ( ! file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . $file ) ) {
-            if ( is_multisite() ) {
-                //multisite fix for old customers
-                $baseurl = str_replace( '/sites/' . get_current_blog_id() . '/', '/', $baseurl );
-            }
-        }
+		$baseurl = UM()->uploader()->get_upload_base_url();
+		if ( ! file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . $file ) ) {
+			if ( is_multisite() ) {
+				//multisite fix for old customers
+				$baseurl = str_replace( '/sites/' . get_current_blog_id() . '/', '/', $baseurl );
+			}
+		}
 
-        if ( ! empty( $filedata['original_name'] ) ) {
-            $v = '<a href="' . esc_attr( $baseurl . um_user( 'ID' ) . '/' . $file ) . '">' . esc_html( $filedata['original_name'] ) . '</a>';
-        } else {
-            $v = $baseurl . um_user( 'ID' ) . '/' . $file;
-        }
-    }
+		if ( ! empty( $filedata['original_name'] ) ) {
+			$v = '<a href="' . esc_attr( $baseurl . um_user( 'ID' ) . '/' . $file ) . '">' . esc_html( $filedata['original_name'] ) . '</a>';
+		} else {
+			$v = $baseurl . um_user( 'ID' ) . '/' . $file;
+		}
+	}
 
-    if ( is_array( $v ) ) {
-        $v = implode( ',', $v );
-    }
+	if ( is_array( $v ) ) {
+		$v = implode( ',', $v );
+	}
 
-    if ( $k == 'timestamp' ) {
-        $k = __( 'date submitted', 'ultimate-member' );
-        $v = date( "d M Y H:i", $v );
-    }
+	if ( $k == 'timestamp' ) {
+		$k = __( 'date submitted', 'ultimate-member' );
+		$v = date( "d M Y H:i", $v );
+	}
 
-    if ( $style ) {
-        if ( ! $v ) {
-            $v = __( '(empty)', 'ultimate-member' );
-        }
-        $output .= "<p><label>$title: </label><span>$v</span></p>";
-    } else {
-        $output .= "$title: $v" . "<br />";
-    }
+	if ( $style ) {
+		if ( ! $v ) {
+			$v = __( '(empty)', 'ultimate-member' );
+		}
+		$output .= "<p><label>$title: </label><span>$v</span></p>";
+	} else {
+		$output .= "$title: $v" . "<br />";
+	}
 
-    return $output;
+	return $output;
 }
 
 
@@ -914,19 +914,19 @@ function um_user_submited_display( $k, $title, $data = array(), $style = true ) 
  * @return string
  */
 function um_filtered_social_link( $key, $match ) {
-    $value = um_profile( $key );
-    $submatch = str_replace( 'https://', '', $match );
-    $submatch = str_replace( 'http://', '', $submatch );
-    if ( strstr( $value, $submatch ) ) {
-        $value = 'https://' . $value;
-    } elseif ( strpos( $value, 'http' ) !== 0 ) {
-        $value = $match . $value;
-    }
-    $value = str_replace( 'https://https://', 'https://', $value );
-    $value = str_replace( 'http://https://', 'https://', $value );
-    $value = str_replace( 'https://http://', 'https://', $value );
+	$value = um_profile( $key );
+	$submatch = str_replace( 'https://', '', $match );
+	$submatch = str_replace( 'http://', '', $submatch );
+	if ( strstr( $value, $submatch ) ) {
+		$value = 'https://' . $value;
+	} elseif ( strpos( $value, 'http' ) !== 0 ) {
+		$value = $match . $value;
+	}
+	$value = str_replace( 'https://https://', 'https://', $value );
+	$value = str_replace( 'http://https://', 'https://', $value );
+	$value = str_replace( 'https://http://', 'https://', $value );
 
-    return $value;
+	return $value;
 }
 
 
@@ -938,88 +938,88 @@ function um_filtered_social_link( $key, $match ) {
  * @return mixed|string|void
  */
 function um_filtered_value( $key, $data = false ) {
-    $value = um_user( $key );
-    if ( is_array( $value ) ) {
-        $value = add_magic_quotes( $value );
-    }
+	$value = um_user( $key );
+	if ( is_array( $value ) ) {
+		$value = add_magic_quotes( $value );
+	}
 
-    if ( ! $data ) {
-        $data = UM()->builtin()->get_specific_field( $key );
-    }
+	if ( ! $data ) {
+		$data = UM()->builtin()->get_specific_field( $key );
+	}
 
-    $type = ( isset( $data['type'] ) ) ? $data['type'] : '';
+	$type = ( isset( $data['type'] ) ) ? $data['type'] : '';
 
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_profile_field_filter_hook__
-     * @description Change or filter field value
-     * @input_vars
-     * [{"var":"$value","type":"string","desc":"Field Value"},
-     * {"var":"$data","type":"array","desc":"Field Data"},
-     * {"var":"$type","type":"string","desc":"Field Type"}]
-     * @change_log
-     * ["Since: 2.0"]
-     * @usage add_filter( 'um_profile_field_filter_hook__', 'function_name', 10, 3 );
-     * @example
-     * <?php
-     * add_filter( 'um_profile_field_filter_hook__', 'my_profile_field', 10, 3 );
-     * function my_profile_field( $value, $data, $type ) {
-     *     // your code here
-     *     return $value;
-     * }
-     * ?>
-     */
-    $value = apply_filters( 'um_profile_field_filter_hook__', $value, $data, $type );
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_profile_field_filter_hook__
+	 * @description Change or filter field value
+	 * @input_vars
+	 * [{"var":"$value","type":"string","desc":"Field Value"},
+	 * {"var":"$data","type":"array","desc":"Field Data"},
+	 * {"var":"$type","type":"string","desc":"Field Type"}]
+	 * @change_log
+	 * ["Since: 2.0"]
+	 * @usage add_filter( 'um_profile_field_filter_hook__', 'function_name', 10, 3 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_profile_field_filter_hook__', 'my_profile_field', 10, 3 );
+	 * function my_profile_field( $value, $data, $type ) {
+	 *     // your code here
+	 *     return $value;
+	 * }
+	 * ?>
+	 */
+	$value = apply_filters( 'um_profile_field_filter_hook__', $value, $data, $type );
 
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_profile_field_filter_hook__{$key}
-     * @description Change or filter field value by field key ($key)
-     * @input_vars
-     * [{"var":"$value","type":"string","desc":"Field Value"},
-     * {"var":"$data","type":"array","desc":"Field Data"}]
-     * @change_log
-     * ["Since: 2.0"]
-     * @usage add_filter( 'um_profile_field_filter_hook__{$key}', 'function_name', 10, 2 );
-     * @example
-     * <?php
-     * add_filter( 'um_profile_field_filter_hook__{$key}', 'my_profile_field', 10, 2 );
-     * function my_profile_field( $value, $data ) {
-     *     // your code here
-     *     return $value;
-     * }
-     * ?>
-     */
-    $value = apply_filters( "um_profile_field_filter_hook__{$key}", $value, $data );
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_profile_field_filter_hook__{$key}
+	 * @description Change or filter field value by field key ($key)
+	 * @input_vars
+	 * [{"var":"$value","type":"string","desc":"Field Value"},
+	 * {"var":"$data","type":"array","desc":"Field Data"}]
+	 * @change_log
+	 * ["Since: 2.0"]
+	 * @usage add_filter( 'um_profile_field_filter_hook__{$key}', 'function_name', 10, 2 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_profile_field_filter_hook__{$key}', 'my_profile_field', 10, 2 );
+	 * function my_profile_field( $value, $data ) {
+	 *     // your code here
+	 *     return $value;
+	 * }
+	 * ?>
+	 */
+	$value = apply_filters( "um_profile_field_filter_hook__{$key}", $value, $data );
 
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_profile_field_filter_hook__{$type}
-     * @description Change or filter field value by field type ($type)
-     * @input_vars
-     * [{"var":"$value","type":"string","desc":"Field Value"},
-     * {"var":"$data","type":"array","desc":"Field Data"}]
-     * @change_log
-     * ["Since: 2.0"]
-     * @usage add_filter( 'um_profile_field_filter_hook__{$type}', 'function_name', 10, 2 );
-     * @example
-     * <?php
-     * add_filter( 'um_profile_field_filter_hook__{$type}', 'my_profile_field', 10, 2 );
-     * function my_profile_field( $value, $data ) {
-     *     // your code here
-     *     return $value;
-     * }
-     * ?>
-     */
-    $value = apply_filters( "um_profile_field_filter_hook__{$type}", $value, $data );
-    $value = UM()->shortcodes()->emotize( $value );
-    return $value;
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_profile_field_filter_hook__{$type}
+	 * @description Change or filter field value by field type ($type)
+	 * @input_vars
+	 * [{"var":"$value","type":"string","desc":"Field Value"},
+	 * {"var":"$data","type":"array","desc":"Field Data"}]
+	 * @change_log
+	 * ["Since: 2.0"]
+	 * @usage add_filter( 'um_profile_field_filter_hook__{$type}', 'function_name', 10, 2 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_profile_field_filter_hook__{$type}', 'my_profile_field', 10, 2 );
+	 * function my_profile_field( $value, $data ) {
+	 *     // your code here
+	 *     return $value;
+	 * }
+	 * ?>
+	 */
+	$value = apply_filters( "um_profile_field_filter_hook__{$type}", $value, $data );
+	$value = UM()->shortcodes()->emotize( $value );
+	return $value;
 }
 
 
@@ -1029,15 +1029,15 @@ function um_filtered_value( $key, $data = false ) {
  * @return int
  */
 function um_profile_id() {
-    $requested_user = um_get_requested_user();
+	$requested_user = um_get_requested_user();
 
-    if ( $requested_user ) {
-        return um_get_requested_user();
-    } elseif ( is_user_logged_in() && get_current_user_id() ) {
-        return get_current_user_id();
-    }
+	if ( $requested_user ) {
+		return um_get_requested_user();
+	} elseif ( is_user_logged_in() && get_current_user_id() ) {
+		return get_current_user_id();
+	}
 
-    return 0;
+	return 0;
 }
 
 
@@ -1049,34 +1049,34 @@ function um_profile_id() {
  * @return bool|string
  */
 function um_is_temp_upload( $url ) {
-    if ( is_string( $url ) ) {
-        $url = trim( $url );
-    }
+	if ( is_string( $url ) ) {
+		$url = trim( $url );
+	}
 
-    if ( filter_var( $url, FILTER_VALIDATE_URL ) === false ) {
-        $url = realpath( $url );
-    }
+	if ( filter_var( $url, FILTER_VALIDATE_URL ) === false ) {
+		$url = realpath( $url );
+	}
 
-    if ( ! $url ) {
-        return false;
-    }
+	if ( ! $url ) {
+		return false;
+	}
 
-    $url = explode( '/ultimatemember/temp/', $url );
-    if ( isset( $url[1] ) ) {
+	$url = explode( '/ultimatemember/temp/', $url );
+	if ( isset( $url[1] ) ) {
 
-        if ( strstr( $url[1], '../' ) || strstr( $url[1], '%' ) ) {
-            return false;
-        }
+		if ( strstr( $url[1], '../' ) || strstr( $url[1], '%' ) ) {
+			return false;
+		}
 
-        $src = UM()->files()->upload_temp . $url[1];
-        if ( ! file_exists( $src ) ) {
-            return false;
-        }
+		$src = UM()->files()->upload_temp . $url[1];
+		if ( ! file_exists( $src ) ) {
+			return false;
+		}
 
-        return $src;
-    }
+		return $src;
+	}
 
-    return false;
+	return false;
 }
 
 
@@ -1088,17 +1088,17 @@ function um_is_temp_upload( $url ) {
  * @return bool|string
  */
 function um_is_temp_image( $url ) {
-    $url = explode( '/ultimatemember/temp/', $url );
-    if (isset( $url[1] )) {
-        $src = UM()->files()->upload_temp . $url[1];
-        if (!file_exists( $src ))
-            return false;
-        list( $width, $height, $type, $attr ) = @getimagesize( $src );
-        if (isset( $width ) && isset( $height ))
-            return $src;
-    }
+	$url = explode( '/ultimatemember/temp/', $url );
+	if (isset( $url[1] )) {
+		$src = UM()->files()->upload_temp . $url[1];
+		if (!file_exists( $src ))
+			return false;
+		list( $width, $height, $type, $attr ) = @getimagesize( $src );
+		if (isset( $width ) && isset( $height ))
+			return $src;
+	}
 
-    return false;
+	return false;
 }
 
 
@@ -1111,24 +1111,24 @@ function um_is_temp_image( $url ) {
  */
 function um_is_file_owner( $url, $user_id = null, $image_path = false ) {
 
-    if ( strpos( $url, UM()->uploader()->get_upload_base_url() . $user_id . '/' ) !== false && is_user_logged_in() ) {
-        $user_basedir = UM()->uploader()->get_upload_user_base_dir( $user_id );
-    } else {
-        $user_basedir = UM()->uploader()->get_upload_user_base_dir( 'temp' );
-    }
+	if ( strpos( $url, UM()->uploader()->get_upload_base_url() . $user_id . '/' ) !== false && is_user_logged_in() ) {
+		$user_basedir = UM()->uploader()->get_upload_user_base_dir( $user_id );
+	} else {
+		$user_basedir = UM()->uploader()->get_upload_user_base_dir( 'temp' );
+	}
 
-    $filename = wp_basename( parse_url( $url, PHP_URL_PATH ) );
+	$filename = wp_basename( parse_url( $url, PHP_URL_PATH ) );
 
-    $file = $user_basedir . DIRECTORY_SEPARATOR . $filename;
-    if ( file_exists( $file ) ) {
-        if ( $image_path ) {
-            return $file;
-        }
+	$file = $user_basedir . DIRECTORY_SEPARATOR . $filename;
+	if ( file_exists( $file ) ) {
+		if ( $image_path ) {
+			return $file;
+		}
 
-        return true;
-    }
+		return true;
+	}
 
-    return false;
+	return false;
 }
 
 
@@ -1138,14 +1138,14 @@ function um_is_file_owner( $url, $user_id = null, $image_path = false ) {
  * @return bool
  */
 function um_is_temp_file( $filename ) {
-    $user_basedir = UM()->uploader()->get_upload_user_base_dir( 'temp' );
+	$user_basedir = UM()->uploader()->get_upload_user_base_dir( 'temp' );
 
-    $file = $user_basedir . '/' . $filename;
+	$file = $user_basedir . '/' . $filename;
 
-    if ( file_exists( $file ) ) {
-        return true;
-    }
-    return false;
+	if ( file_exists( $file ) ) {
+		return true;
+	}
+	return false;
 }
 
 
@@ -1157,12 +1157,12 @@ function um_is_temp_file( $filename ) {
  * @return mixed|string
  */
 function um_user_last_login_timestamp( $user_id ) {
-    $value = get_user_meta( $user_id, '_um_last_login', true );
-    if ( $value ) {
-        return $value;
-    }
+	$value = get_user_meta( $user_id, '_um_last_login', true );
+	if ( $value ) {
+		return $value;
+	}
 
-    return '';
+	return '';
 }
 
 
@@ -1174,8 +1174,8 @@ function um_user_last_login_timestamp( $user_id ) {
  * @return string
  */
 function um_user_last_login( $user_id ) {
-    $value = get_user_meta( $user_id, '_um_last_login', true );
-    return ! empty( $value ) ? UM()->datetime()->time_diff( $value, current_time( 'timestamp' ) ) : '';
+	$value = get_user_meta( $user_id, '_um_last_login', true );
+	return ! empty( $value ) ? UM()->datetime()->time_diff( $value, current_time( 'timestamp' ) ) : '';
 }
 
 
@@ -1188,38 +1188,38 @@ function um_user_last_login( $user_id ) {
  * @return bool|false|mixed|string|void
  */
 function um_get_core_page( $slug, $updated = false ) {
-    $url = '';
+	$url = '';
 
-    if ( isset( UM()->config()->permalinks[ $slug ] ) ) {
-        $url = get_permalink( UM()->config()->permalinks[ $slug ] );
-        if ( $updated ) {
-            $url = add_query_arg( 'updated', esc_attr( $updated ), $url );
-        }
-    }
+	if ( isset( UM()->config()->permalinks[ $slug ] ) ) {
+		$url = get_permalink( UM()->config()->permalinks[ $slug ] );
+		if ( $updated ) {
+			$url = add_query_arg( 'updated', esc_attr( $updated ), $url );
+		}
+	}
 
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_get_core_page_filter
-     * @description Change UM core page URL
-     * @input_vars
-     * [{"var":"$url","type":"string","desc":"UM Page URL"},
-     * {"var":"$slug","type":"string","desc":"UM Page slug"},
-     * {"var":"$updated","type":"bool","desc":"Additional parameter"}]
-     * @change_log
-     * ["Since: 2.0"]
-     * @usage add_filter( 'um_get_core_page_filter', 'function_name', 10, 3 );
-     * @example
-     * <?php
-     * add_filter( 'um_get_core_page_filter', 'my_core_page_url', 10, 3 );
-     * function my_core_page_url( $url, $slug, $updated ) {
-     *     // your code here
-     *     return $url;
-     * }
-     * ?>
-     */
-    return apply_filters( 'um_get_core_page_filter', $url, $slug, $updated );
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_get_core_page_filter
+	 * @description Change UM core page URL
+	 * @input_vars
+	 * [{"var":"$url","type":"string","desc":"UM Page URL"},
+	 * {"var":"$slug","type":"string","desc":"UM Page slug"},
+	 * {"var":"$updated","type":"bool","desc":"Additional parameter"}]
+	 * @change_log
+	 * ["Since: 2.0"]
+	 * @usage add_filter( 'um_get_core_page_filter', 'function_name', 10, 3 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_get_core_page_filter', 'my_core_page_url', 10, 3 );
+	 * function my_core_page_url( $url, $slug, $updated ) {
+	 *     // your code here
+	 *     return $url;
+	 * }
+	 * ?>
+	 */
+	return apply_filters( 'um_get_core_page_filter', $url, $slug, $updated );
 }
 
 
@@ -1234,59 +1234,59 @@ function um_get_core_page( $slug, $updated = false ) {
  * @return bool
  */
 function um_is_core_page( $page ) {
-    global $post;
+	global $post;
 
-    if ( empty( $post ) ) {
-        return false;
-    }
+	if ( empty( $post ) ) {
+		return false;
+	}
 
-    if ( isset( $post->ID ) && isset( UM()->config()->permalinks[ $page ] ) && $post->ID == UM()->config()->permalinks[ $page ] ) {
-        return true;
-    }
+	if ( isset( $post->ID ) && isset( UM()->config()->permalinks[ $page ] ) && $post->ID == UM()->config()->permalinks[ $page ] ) {
+		return true;
+	}
 
-    if ( isset( $post->ID ) && get_post_meta( $post->ID, '_um_wpml_' . $page, true ) == 1 ) {
-        return true;
-    }
+	if ( isset( $post->ID ) && get_post_meta( $post->ID, '_um_wpml_' . $page, true ) == 1 ) {
+		return true;
+	}
 
-    if ( UM()->external_integrations()->is_wpml_active() ) {
-        global $sitepress;
-        if ( isset( UM()->config()->permalinks[ $page ] ) && UM()->config()->permalinks[ $page ] == wpml_object_id_filter( $post->ID, 'page', true, $sitepress->get_default_language() ) ) {
-            return true;
-        }
-    }
+	if ( UM()->external_integrations()->is_wpml_active() ) {
+		global $sitepress;
+		if ( isset( UM()->config()->permalinks[ $page ] ) && UM()->config()->permalinks[ $page ] == wpml_object_id_filter( $post->ID, 'page', true, $sitepress->get_default_language() ) ) {
+			return true;
+		}
+	}
 
-    if ( isset( $post->ID ) ) {
-        $_icl_lang_duplicate_of = get_post_meta( $post->ID, '_icl_lang_duplicate_of', true );
+	if ( isset( $post->ID ) ) {
+		$_icl_lang_duplicate_of = get_post_meta( $post->ID, '_icl_lang_duplicate_of', true );
 
-        if ( isset( UM()->config()->permalinks[ $page ] ) && ( ( $_icl_lang_duplicate_of == UM()->config()->permalinks[ $page ] && !empty( $_icl_lang_duplicate_of ) ) || UM()->config()->permalinks[ $page ] == $post->ID ) ) {
-            return true;
-        }
-    }
+		if ( isset( UM()->config()->permalinks[ $page ] ) && ( ( $_icl_lang_duplicate_of == UM()->config()->permalinks[ $page ] && !empty( $_icl_lang_duplicate_of ) ) || UM()->config()->permalinks[ $page ] == $post->ID ) ) {
+			return true;
+		}
+	}
 
 
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_is_core_page_filter
-     * @description Change UM is core page returned value
-     * @input_vars
-     * [{"var":"$is_core_page","type":"bool","desc":"Is core page slug a core page"},
-     * {"var":"$page","type":"string","desc":"UM core page slug"},
-     * {"var":"$post","type":"array","desc":"Post data"}]
-     * @change_log
-     * ["Personal addition - PR"]
-     * @usage add_filter( 'um_is_core_page_filter', 'function_name', 10, 3 );
-     * @example
-     * <?php
-     * add_filter( 'um_is_core_page_filter', 'my_is_core_page_filter', 10, 3 );
-     * function my_is_core_page_filter( $is_core_page, $page, $post ) {
-     *     // your code here
-     *     return $is_core_page;
-     * }
-     * ?>
-     */
-    return apply_filters( 'um_is_core_page_filter', false, $page, $post );
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_is_core_page_filter
+	 * @description Change UM is core page returned value
+	 * @input_vars
+	 * [{"var":"$is_core_page","type":"bool","desc":"Is core page slug a core page"},
+	 * {"var":"$page","type":"string","desc":"UM core page slug"},
+	 * {"var":"$post","type":"array","desc":"Post data"}]
+	 * @change_log
+	 * ["Personal addition - PR"]
+	 * @usage add_filter( 'um_is_core_page_filter', 'function_name', 10, 3 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_is_core_page_filter', 'my_is_core_page_filter', 10, 3 );
+	 * function my_is_core_page_filter( $is_core_page, $page, $post ) {
+	 *     // your code here
+	 *     return $is_core_page;
+	 * }
+	 * ?>
+	 */
+	return apply_filters( 'um_is_core_page_filter', false, $page, $post );
 }
 
 
@@ -1297,22 +1297,22 @@ function um_is_core_page( $page ) {
  * @return bool
  */
 function um_is_core_post( $post, $core_page ) {
-    if ( isset( $post->ID ) && isset( UM()->config()->permalinks[ $core_page ] ) && $post->ID == UM()->config()->permalinks[ $core_page ] ) {
-        return true;
-    }
-    if ( isset( $post->ID ) && get_post_meta( $post->ID, '_um_wpml_' . $core_page, true ) == 1 ) {
-        return true;
-    }
+	if ( isset( $post->ID ) && isset( UM()->config()->permalinks[ $core_page ] ) && $post->ID == UM()->config()->permalinks[ $core_page ] ) {
+		return true;
+	}
+	if ( isset( $post->ID ) && get_post_meta( $post->ID, '_um_wpml_' . $core_page, true ) == 1 ) {
+		return true;
+	}
 
-    if ( isset( $post->ID ) ) {
-        $_icl_lang_duplicate_of = get_post_meta( $post->ID, '_icl_lang_duplicate_of', true );
+	if ( isset( $post->ID ) ) {
+		$_icl_lang_duplicate_of = get_post_meta( $post->ID, '_icl_lang_duplicate_of', true );
 
-        if ( isset( UM()->config()->permalinks[ $core_page ] ) && ( ( $_icl_lang_duplicate_of == UM()->config()->permalinks[ $core_page ] && ! empty( $_icl_lang_duplicate_of ) ) || UM()->config()->permalinks[ $core_page ] == $post->ID ) ) {
-            return true;
-        }
-    }
+		if ( isset( UM()->config()->permalinks[ $core_page ] ) && ( ( $_icl_lang_duplicate_of == UM()->config()->permalinks[ $core_page ] && ! empty( $_icl_lang_duplicate_of ) ) || UM()->config()->permalinks[ $core_page ] == $post->ID ) ) {
+			return true;
+		}
+	}
 
-    return false;
+	return false;
 }
 
 
@@ -1325,23 +1325,23 @@ function um_is_core_post( $post, $core_page ) {
  */
 function um_styling_defaults( $mode ) {
 
-    $new_arr = array();
-    $core_form_meta_all = UM()->config()->core_form_meta_all;
-    $core_global_meta_all = UM()->config()->core_global_meta_all;
+	$new_arr = array();
+	$core_form_meta_all = UM()->config()->core_form_meta_all;
+	$core_global_meta_all = UM()->config()->core_global_meta_all;
 
-    foreach ( $core_form_meta_all as $k => $v ) {
-        $s = str_replace( $mode . '_', '', $k );
-        if (strstr( $k, '_um_' . $mode . '_' ) && !in_array( $s, $core_global_meta_all )) {
-            $a = str_replace( '_um_' . $mode . '_', '', $k );
-            $b = str_replace( '_um_', '', $k );
-            $new_arr[$a] = UM()->options()->get( $b );
-        } else if (in_array( $k, $core_global_meta_all )) {
-            $a = str_replace( '_um_', '', $k );
-            $new_arr[$a] = UM()->options()->get( $a );
-        }
-    }
+	foreach ( $core_form_meta_all as $k => $v ) {
+		$s = str_replace( $mode . '_', '', $k );
+		if (strstr( $k, '_um_' . $mode . '_' ) && !in_array( $s, $core_global_meta_all )) {
+			$a = str_replace( '_um_' . $mode . '_', '', $k );
+			$b = str_replace( '_um_', '', $k );
+			$new_arr[$a] = UM()->options()->get( $b );
+		} else if (in_array( $k, $core_global_meta_all )) {
+			$a = str_replace( '_um_', '', $k );
+			$new_arr[$a] = UM()->options()->get( $a );
+		}
+	}
 
-    return $new_arr;
+	return $new_arr;
 }
 
 
@@ -1353,9 +1353,9 @@ function um_styling_defaults( $mode ) {
  * @return string
  */
 function um_get_metadefault( $id ) {
-    $core_form_meta_all = UM()->config()->core_form_meta_all;
+	$core_form_meta_all = UM()->config()->core_form_meta_all;
 
-    return isset( $core_form_meta_all[ '_um_' . $id ] ) ? $core_form_meta_all[ '_um_' . $id ] : '';
+	return isset( $core_form_meta_all[ '_um_' . $id ] ) ? $core_form_meta_all[ '_um_' . $id ] : '';
 }
 
 
@@ -1365,11 +1365,11 @@ function um_get_metadefault( $id ) {
  * @return bool
  */
 function um_submitting_account_page() {
-    if ( isset( $_POST['_um_account'] ) && $_POST['_um_account'] == 1 && is_user_logged_in() ) {
-        return true;
-    }
+	if ( isset( $_POST['_um_account'] ) && $_POST['_um_account'] == 1 && is_user_logged_in() ) {
+		return true;
+	}
 
-    return false;
+	return false;
 }
 
 
@@ -1381,11 +1381,11 @@ function um_submitting_account_page() {
  * @return string
  */
 function um_get_display_name( $user_id ) {
-    um_fetch_user( $user_id );
-    $name = um_user( 'display_name' );
-    um_reset_user();
+	um_fetch_user( $user_id );
+	$name = um_user( 'display_name' );
+	um_reset_user();
 
-    return $name;
+	return $name;
 }
 
 
@@ -1404,7 +1404,7 @@ function um_get_display_name( $user_id ) {
  * <?php um_reset_user_clean(); ?>
  */
 function um_reset_user_clean() {
-    UM()->user()->reset( true );
+	UM()->user()->reset( true );
 }
 
 
@@ -1423,7 +1423,7 @@ function um_reset_user_clean() {
  * <?php um_reset_user(); ?>
  */
 function um_reset_user() {
-    UM()->user()->reset();
+	UM()->user()->reset();
 }
 
 
@@ -1433,7 +1433,7 @@ function um_reset_user() {
  * @return mixed
  */
 function um_queried_user() {
-    return get_query_var( 'um_user' );
+	return get_query_var( 'um_user' );
 }
 
 
@@ -1443,7 +1443,7 @@ function um_queried_user() {
  * @param $user_id
  */
 function um_set_requested_user( $user_id ) {
-    UM()->user()->target_id = $user_id;
+	UM()->user()->target_id = $user_id;
 }
 
 
@@ -1453,11 +1453,11 @@ function um_set_requested_user( $user_id ) {
  * @return bool|null
  */
 function um_get_requested_user() {
-    if ( ! empty( UM()->user()->target_id ) ) {
-        return UM()->user()->target_id;
-    }
+	if ( ! empty( UM()->user()->target_id ) ) {
+		return UM()->user()->target_id;
+	}
 
-    return false;
+	return false;
 }
 
 
@@ -1470,35 +1470,35 @@ function um_get_requested_user() {
  */
 function um_edit_my_profile_cancel_uri( $url = '' ) {
 
-    if ( empty( $url ) ) {
-        $url = remove_query_arg( 'um_action' );
-        $url = remove_query_arg( 'profiletab', $url );
-        $url = add_query_arg( 'profiletab', 'main', $url );
-    }
+	if ( empty( $url ) ) {
+		$url = remove_query_arg( 'um_action' );
+		$url = remove_query_arg( 'profiletab', $url );
+		$url = add_query_arg( 'profiletab', 'main', $url );
+	}
 
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_edit_profile_cancel_uri
-     * @description Change Edit Profile Cancel URL
-     * @input_vars
-     * [{"var":"$url","type":"string","desc":"Cancel URL"}]
-     * @change_log
-     * ["Since: 2.0"]
-     * @usage add_filter( 'um_edit_profile_cancel_uri', 'function_name', 10, 1 );
-     * @example
-     * <?php
-     * add_filter( 'um_edit_profile_cancel_uri', 'my_edit_profile_cancel_uri', 10, 1 );
-     * function my_edit_profile_cancel_uri( $url ) {
-     *     // your code here
-     *     return $url;
-     * }
-     * ?>
-     */
-    $url = apply_filters( 'um_edit_profile_cancel_uri', $url );
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_edit_profile_cancel_uri
+	 * @description Change Edit Profile Cancel URL
+	 * @input_vars
+	 * [{"var":"$url","type":"string","desc":"Cancel URL"}]
+	 * @change_log
+	 * ["Since: 2.0"]
+	 * @usage add_filter( 'um_edit_profile_cancel_uri', 'function_name', 10, 1 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_edit_profile_cancel_uri', 'my_edit_profile_cancel_uri', 10, 1 );
+	 * function my_edit_profile_cancel_uri( $url ) {
+	 *     // your code here
+	 *     return $url;
+	 * }
+	 * ?>
+	 */
+	$url = apply_filters( 'um_edit_profile_cancel_uri', $url );
 
-    return $url;
+	return $url;
 }
 
 
@@ -1508,11 +1508,11 @@ function um_edit_my_profile_cancel_uri( $url = '' ) {
  * @return bool
  */
 function um_is_on_edit_profile() {
-    if ( isset( $_REQUEST['um_action'] ) && $_REQUEST['um_action'] == 'edit' ) {
-        return true;
-    }
+	if ( isset( $_REQUEST['um_action'] ) && $_REQUEST['um_action'] == 'edit' ) {
+		return true;
+	}
 
-    return false;
+	return false;
 }
 
 
@@ -1524,68 +1524,68 @@ function um_is_on_edit_profile() {
  * @return bool
  */
 function um_can_view_field( $data ) {
-    $can_view = true;
+	$can_view = true;
 
-    if ( ! isset( UM()->fields()->set_mode ) ) {
-        UM()->fields()->set_mode = '';
-    }
+	if ( ! isset( UM()->fields()->set_mode ) ) {
+		UM()->fields()->set_mode = '';
+	}
 
-    if ( isset( $data['public'] ) && UM()->fields()->set_mode != 'register' ) {
+	if ( isset( $data['public'] ) && UM()->fields()->set_mode != 'register' ) {
 
-        if ( is_user_logged_in() ) {
-            $previous_user = um_user( 'ID' );
-            um_fetch_user( get_current_user_id() );
+		if ( is_user_logged_in() ) {
+			$previous_user = um_user( 'ID' );
+			um_fetch_user( get_current_user_id() );
 
-            $current_user_roles = um_user( 'roles' );
-            um_fetch_user( $previous_user );
-        }
+			$current_user_roles = um_user( 'roles' );
+			um_fetch_user( $previous_user );
+		}
 
-        switch ( $data['public'] ) {
-            case '1':
-                $can_view = true;
-                break;
-            case '2':
-                if ( ! is_user_logged_in() ) {
-                    $can_view = false;
-                }
-                break;
-            case '-1':
-                if ( ! is_user_logged_in() ) {
-                    $can_view = false;
-                } else {
-                    if ( ! um_is_user_himself() && ! UM()->roles()->um_user_can( 'can_edit_everyone' ) ) {
-                        $can_view = false;
-                    }
-                }
-                break;
-            case '-2':
-                if ( ! is_user_logged_in() ) {
-                    $can_view = false;
-                } else {
-                    if ( ! empty( $data['roles'] ) ) {
-                        if ( empty( $current_user_roles ) || count( array_intersect( $current_user_roles, $data['roles'] ) ) <= 0 ) {
-                            $can_view = false;
-                        }
-                    }
-                }
-                break;
-            case '-3':
-                if ( ! is_user_logged_in() ) {
-                    $can_view = false;
-                } else {
-                    if ( ! um_is_user_himself() && ( empty( $current_user_roles ) || ( ! empty( $data['roles'] ) && count( array_intersect( $current_user_roles, $data['roles'] ) ) <= 0 ) ) ) {
-                        $can_view = false;
-                    }
-                }
-                break;
-            default:
-                $can_view = apply_filters( 'um_can_view_field_custom', $can_view, $data );
-                break;
-        }
+		switch ( $data['public'] ) {
+			case '1':
+				$can_view = true;
+				break;
+			case '2':
+				if ( ! is_user_logged_in() ) {
+					$can_view = false;
+				}
+				break;
+			case '-1':
+				if ( ! is_user_logged_in() ) {
+					$can_view = false;
+				} else {
+					if ( ! um_is_user_himself() && ! UM()->roles()->um_user_can( 'can_edit_everyone' ) ) {
+						$can_view = false;
+					}
+				}
+				break;
+			case '-2':
+				if ( ! is_user_logged_in() ) {
+					$can_view = false;
+				} else {
+					if ( ! empty( $data['roles'] ) ) {
+						if ( empty( $current_user_roles ) || count( array_intersect( $current_user_roles, $data['roles'] ) ) <= 0 ) {
+							$can_view = false;
+						}
+					}
+				}
+				break;
+			case '-3':
+				if ( ! is_user_logged_in() ) {
+					$can_view = false;
+				} else {
+					if ( ! um_is_user_himself() && ( empty( $current_user_roles ) || ( ! empty( $data['roles'] ) && count( array_intersect( $current_user_roles, $data['roles'] ) ) <= 0 ) ) ) {
+						$can_view = false;
+					}
+				}
+				break;
+			default:
+				$can_view = apply_filters( 'um_can_view_field_custom', $can_view, $data );
+				break;
+		}
 
-    }
+	}
 
-    return apply_filters( 'um_can_view_field', $can_view, $data );
+	return apply_filters( 'um_can_view_field', $can_view, $data );
 }
 
 
@@ -1597,41 +1597,41 @@ function um_can_view_field( $data ) {
  * @return bool
  */
 function um_can_view_profile( $user_id ) {
-    if ( UM()->roles()->um_current_user_can( 'edit', $user_id ) ) {
-        return true;
-    }
+	if ( UM()->roles()->um_current_user_can( 'edit', $user_id ) ) {
+		return true;
+	}
 
-    if ( ! is_user_logged_in() ) {
-        return ! UM()->user()->is_private_profile( $user_id );
-    }
+	if ( ! is_user_logged_in() ) {
+		return ! UM()->user()->is_private_profile( $user_id );
+	}
 
-    $temp_id = um_user('ID');
-    um_fetch_user( get_current_user_id() );
+	$temp_id = um_user('ID');
+	um_fetch_user( get_current_user_id() );
 
-    if ( ! um_user( 'can_view_all' ) && $user_id != get_current_user_id() && is_user_logged_in() ) {
-        um_fetch_user( $temp_id );
-        return false;
-    }
+	if ( ! um_user( 'can_view_all' ) && $user_id != get_current_user_id() && is_user_logged_in() ) {
+		um_fetch_user( $temp_id );
+		return false;
+	}
 
-    if ( ! um_user( 'can_access_private_profile' ) && UM()->user()->is_private_profile( $user_id ) ) {
-        um_fetch_user( $temp_id );
-        return false;
-    }
+	if ( ! um_user( 'can_access_private_profile' ) && UM()->user()->is_private_profile( $user_id ) ) {
+		um_fetch_user( $temp_id );
+		return false;
+	}
 
-    if ( um_user( 'can_view_roles' ) && $user_id != get_current_user_id() ) {
-        $can_view_roles = um_user( 'can_view_roles' );
+	if ( um_user( 'can_view_roles' ) && $user_id != get_current_user_id() ) {
+		$can_view_roles = um_user( 'can_view_roles' );
 
-        if ( ! is_array( $can_view_roles ) ) {
-            $can_view_roles = array();
-        }
+		if ( ! is_array( $can_view_roles ) ) {
+			$can_view_roles = array();
+		}
 
-        if ( count( $can_view_roles ) && count( array_intersect( UM()->roles()->get_all_user_roles( $user_id ), $can_view_roles ) ) <= 0 ) {
-            um_fetch_user( $temp_id );
-            return false;
-        }
-    }
-    um_fetch_user( $temp_id );
-    return true;
+		if ( count( $can_view_roles ) && count( array_intersect( UM()->roles()->get_all_user_roles( $user_id ), $can_view_roles ) ) <= 0 ) {
+			um_fetch_user( $temp_id );
+			return false;
+		}
+	}
+	um_fetch_user( $temp_id );
+	return true;
 }
 
 
@@ -1641,10 +1641,10 @@ function um_can_view_profile( $user_id ) {
  * @return bool
  */
 function um_is_user_himself() {
-    if (um_get_requested_user() && um_get_requested_user() != get_current_user_id())
-        return false;
+	if (um_get_requested_user() && um_get_requested_user() != get_current_user_id())
+		return false;
 
-    return true;
+	return true;
 }
 
 /**
@@ -1655,25 +1655,25 @@ function um_is_user_himself() {
  * @return bool
  */
 function um_can_edit_field( $data ) {
-    $can_edit = true;
+	$can_edit = true;
 
-    if ( ! empty( UM()->fields()->editing ) && isset( UM()->fields()->set_mode ) && UM()->fields()->set_mode == 'profile' ) {
-        if ( ! is_user_logged_in() ) {
-            $can_edit = false;
-        } else {
-            if ( ! UM()->roles()->um_user_can( 'can_edit_everyone' ) ) {
-                if ( isset( $data['editable'] ) && $data['editable'] == 0 ) {
-                    $can_edit = false;
-                } else {
-                    if ( ! um_is_user_himself() ) {
-                        $can_edit = false;
-                    }
-                }
-            }
-        }
-    }
+	if ( ! empty( UM()->fields()->editing ) && isset( UM()->fields()->set_mode ) && UM()->fields()->set_mode == 'profile' ) {
+		if ( ! is_user_logged_in() ) {
+			$can_edit = false;
+		} else {
+			if ( ! UM()->roles()->um_user_can( 'can_edit_everyone' ) ) {
+				if ( isset( $data['editable'] ) && $data['editable'] == 0 ) {
+					$can_edit = false;
+				} else {
+					if ( ! um_is_user_himself() ) {
+						$can_edit = false;
+					}
+				}
+			}
+		}
+	}
 
-    return apply_filters( 'um_can_edit_field', $can_edit, $data );
+	return apply_filters( 'um_can_edit_field', $can_edit, $data );
 }
 
 
@@ -1683,10 +1683,10 @@ function um_can_edit_field( $data ) {
  * @return bool
  */
 function um_is_myprofile() {
-    if (get_current_user_id() && get_current_user_id() == um_get_requested_user()) return true;
-    if (!um_get_requested_user() && um_is_core_page( 'user' ) && get_current_user_id()) return true;
+	if (get_current_user_id() && get_current_user_id() == um_get_requested_user()) return true;
+	if (!um_get_requested_user() && um_is_core_page( 'user' ) && get_current_user_id()) return true;
 
-    return false;
+	return false;
 }
 
 
@@ -1696,17 +1696,17 @@ function um_is_myprofile() {
  * @return string
  */
 function um_edit_profile_url() {
-    if ( um_is_core_page( 'user' ) ) {
-        $url = UM()->permalinks()->get_current_url();
-    } else {
-        $url = um_user_profile_url();
-    }
+	if ( um_is_core_page( 'user' ) ) {
+		$url = UM()->permalinks()->get_current_url();
+	} else {
+		$url = um_user_profile_url();
+	}
 
-    $url = remove_query_arg( 'profiletab', $url );
-    $url = remove_query_arg( 'subnav', $url );
-    $url = add_query_arg( 'um_action', 'edit', $url );
+	$url = remove_query_arg( 'profiletab', $url );
+	$url = remove_query_arg( 'subnav', $url );
+	$url = add_query_arg( 'um_action', 'edit', $url );
 
-    return $url;
+	return $url;
 }
 
 
@@ -1716,11 +1716,11 @@ function um_edit_profile_url() {
  * @return bool
  */
 function um_can_edit_my_profile() {
-    if ( ! is_user_logged_in() || ! um_user( 'can_edit_profile' ) ) {
-        return false;
-    }
+	if ( ! is_user_logged_in() || ! um_user( 'can_edit_profile' ) ) {
+		return false;
+	}
 
-    return true;
+	return true;
 }
 
 
@@ -1730,7 +1730,7 @@ function um_can_edit_my_profile() {
  * @return mixed|string|void
  */
 function um_admin_email() {
-    return UM()->options()->get( 'admin_email' );
+	return UM()->options()->get( 'admin_email' );
 }
 
 
@@ -1740,15 +1740,15 @@ function um_admin_email() {
  * @return array
  */
 function um_multi_admin_email() {
-    $emails = UM()->options()->get( 'admin_email' );
+	$emails = UM()->options()->get( 'admin_email' );
 
-    $emails_array = explode( ',', $emails );
-    if ( ! empty( $emails_array ) ) {
-        $emails_array = array_map( 'trim', $emails_array );
-    }
+	$emails_array = explode( ',', $emails );
+	if ( ! empty( $emails_array ) ) {
+		$emails_array = array_map( 'trim', $emails_array );
+	}
 
-    $emails_array = array_unique( $emails_array );
-    return $emails_array;
+	$emails_array = array_unique( $emails_array );
+	return $emails_array;
 }
 
 
@@ -1760,18 +1760,18 @@ function um_multi_admin_email() {
  * @return bool|string
  */
 function um_user_profile_url( $user_id = false ) {
-    if ( ! $user_id ) {
-        $user_id = um_user( 'ID' );
-    }
+	if ( ! $user_id ) {
+		$user_id = um_user( 'ID' );
+	}
 
-    $url = UM()->user()->get_profile_link( $user_id );
-    if ( empty( $url ) ) {
-        //if empty profile slug - generate it and re-get profile URL
-        UM()->user()->generate_profile_slug( $user_id );
-        $url = UM()->user()->get_profile_link( $user_id );
-    }
+	$url = UM()->user()->get_profile_link( $user_id );
+	if ( empty( $url ) ) {
+		//if empty profile slug - generate it and re-get profile URL
+		UM()->user()->generate_profile_slug( $user_id );
+		$url = UM()->user()->get_profile_link( $user_id );
+	}
 
-    return $url;
+	return $url;
 }
 
 
@@ -1781,7 +1781,7 @@ function um_user_profile_url( $user_id = false ) {
  * @return array
  */
 function um_get_roles() {
-    return UM()->roles()->get_roles();
+	return UM()->roles()->get_roles();
 }
 
 
@@ -1817,7 +1817,7 @@ function um_get_roles() {
  *
  */
 function um_fetch_user( $user_id ) {
-    UM()->user()->set( $user_id );
+	UM()->user()->set( $user_id );
 }
 
 
@@ -1829,53 +1829,53 @@ function um_fetch_user( $user_id ) {
  * @return bool|string
  */
 function um_profile( $key ) {
-    if ( ! empty( UM()->user()->profile[ $key ] ) ) {
-        /**
-         * UM hook
-         *
-         * @type filter
-         * @title um_profile_{$key}__filter
-         * @description Change not empty profile field value
-         * @input_vars
-         * [{"var":"$value","type":"mixed","desc":"Profile Value"}]
-         * @change_log
-         * ["Since: 2.0"]
-         * @usage add_filter( 'um_profile_{$key}__filter', 'function_name', 10, 1 );
-         * @example
-         * <?php
-         * add_filter( 'um_profile_{$key}__filter', 'my_profile_value', 10, 1 );
-         * function my_profile_value( $value ) {
-         *     // your code here
-         *     return $value;
-         * }
-         * ?>
-         */
-        $value = apply_filters( "um_profile_{$key}__filter", UM()->user()->profile[ $key ] );
-    } else {
-        /**
-         * UM hook
-         *
-         * @type filter
-         * @title um_profile_{$key}_empty__filter
-         * @description Change Profile field value if it's empty
-         * @input_vars
-         * [{"var":"$value","type":"mixed","desc":"Profile Value"}]
-         * @change_log
-         * ["Since: 2.0"]
-         * @usage add_filter( 'um_profile_{$key}_empty__filter', 'function_name', 10, 1 );
-         * @example
-         * <?php
-         * add_filter( 'um_profile_{$key}_empty__filter', 'my_profile_value', 10, 1 );
-         * function my_profile_value( $value ) {
-         *     // your code here
-         *     return $value;
-         * }
-         * ?>
-         */
-        $value = apply_filters( "um_profile_{$key}_empty__filter", false );
-    }
+	if ( ! empty( UM()->user()->profile[ $key ] ) ) {
+		/**
+		 * UM hook
+		 *
+		 * @type filter
+		 * @title um_profile_{$key}__filter
+		 * @description Change not empty profile field value
+		 * @input_vars
+		 * [{"var":"$value","type":"mixed","desc":"Profile Value"}]
+		 * @change_log
+		 * ["Since: 2.0"]
+		 * @usage add_filter( 'um_profile_{$key}__filter', 'function_name', 10, 1 );
+		 * @example
+		 * <?php
+		 * add_filter( 'um_profile_{$key}__filter', 'my_profile_value', 10, 1 );
+		 * function my_profile_value( $value ) {
+		 *     // your code here
+		 *     return $value;
+		 * }
+		 * ?>
+		 */
+		$value = apply_filters( "um_profile_{$key}__filter", UM()->user()->profile[ $key ] );
+	} else {
+		/**
+		 * UM hook
+		 *
+		 * @type filter
+		 * @title um_profile_{$key}_empty__filter
+		 * @description Change Profile field value if it's empty
+		 * @input_vars
+		 * [{"var":"$value","type":"mixed","desc":"Profile Value"}]
+		 * @change_log
+		 * ["Since: 2.0"]
+		 * @usage add_filter( 'um_profile_{$key}_empty__filter', 'function_name', 10, 1 );
+		 * @example
+		 * <?php
+		 * add_filter( 'um_profile_{$key}_empty__filter', 'my_profile_value', 10, 1 );
+		 * function my_profile_value( $value ) {
+		 *     // your code here
+		 *     return $value;
+		 * }
+		 * ?>
+		 */
+		$value = apply_filters( "um_profile_{$key}_empty__filter", false );
+	}
 
-    return $value;
+	return $value;
 }
 
 
@@ -1887,8 +1887,8 @@ function um_profile( $key ) {
  * @return bool
  */
 function um_youtube_id_from_url( $url ) {
-    $pattern =
-        '%^# Match any youtube URL
+	$pattern =
+		'%^# Match any youtube URL
 		(?:https?://)?  # Optional scheme. Either http or https
 		(?:www\.)?      # Optional www subdomain
 		(?:             # Group host alternatives
@@ -1902,12 +1902,12 @@ function um_youtube_id_from_url( $url ) {
 		)               # End host alternatives.
 		([\w-]{10,12})  # Allow 10-12 for 11 char youtube id.
 		$%x';
-    $result = preg_match( $pattern, $url, $matches );
-    if (false !== $result) {
-        return $matches[1];
-    }
+	$result = preg_match( $pattern, $url, $matches );
+	if (false !== $result) {
+		return $matches[1];
+	}
 
-    return false;
+	return false;
 }
 
 
@@ -1920,12 +1920,12 @@ function um_youtube_id_from_url( $url ) {
  * @return mixed
  */
 function um_closest_num( $array, $number ) {
-    sort( $array );
-    foreach ( $array as $a ) {
-        if ( $a >= $number ) return $a;
-    }
+	sort( $array );
+	foreach ( $array as $a ) {
+		if ( $a >= $number ) return $a;
+	}
 
-    return end( $array );
+	return end( $array );
 }
 
 
@@ -1938,46 +1938,46 @@ function um_closest_num( $array, $number ) {
  * @return bool|string
  */
 function um_get_cover_uri( $image, $attrs ) {
-    $uri = false;
-    $uri_common = false;
-    $ext = '.' . pathinfo( $image, PATHINFO_EXTENSION );
+	$uri = false;
+	$uri_common = false;
+	$ext = '.' . pathinfo( $image, PATHINFO_EXTENSION );
 
-    $ratio = str_replace(':1','',UM()->options()->get( 'profile_cover_ratio' ) );
-    $height = round( $attrs / $ratio );
+	$ratio = str_replace(':1','',UM()->options()->get( 'profile_cover_ratio' ) );
+	$height = round( $attrs / $ratio );
 
-    if ( is_multisite() ) {
-        //multisite fix for old customers
-        $multisite_fix_dir = UM()->uploader()->get_upload_base_dir();
-        $multisite_fix_url = UM()->uploader()->get_upload_base_url();
-        $multisite_fix_dir = str_replace( DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . get_current_blog_id() . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, $multisite_fix_dir );
-        $multisite_fix_url = str_replace( '/sites/' . get_current_blog_id() . '/', '/', $multisite_fix_url );
+	if ( is_multisite() ) {
+		//multisite fix for old customers
+		$multisite_fix_dir = UM()->uploader()->get_upload_base_dir();
+		$multisite_fix_url = UM()->uploader()->get_upload_base_url();
+		$multisite_fix_dir = str_replace( DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . get_current_blog_id() . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, $multisite_fix_dir );
+		$multisite_fix_url = str_replace( '/sites/' . get_current_blog_id() . '/', '/', $multisite_fix_url );
 
-        if ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo{$ext}" ) ) {
-            $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/cover_photo{$ext}?" . current_time( 'timestamp' );
-        }
+		if ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo{$ext}" ) ) {
+			$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/cover_photo{$ext}?" . current_time( 'timestamp' );
+		}
 
-        if ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}{$ext}" ) ) {
-            $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/cover_photo-{$attrs}{$ext}?" . current_time( 'timestamp' );
-        }elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}x{$height}{$ext}" ) ) {
-            $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/cover_photo-{$attrs}x{$height}{$ext}?". current_time( 'timestamp' );
-        }
-    }
+		if ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}{$ext}" ) ) {
+			$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/cover_photo-{$attrs}{$ext}?" . current_time( 'timestamp' );
+		}elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}x{$height}{$ext}" ) ) {
+			$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/cover_photo-{$attrs}x{$height}{$ext}?". current_time( 'timestamp' );
+		}
+	}
 
-    if ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo{$ext}" ) ) {
-        $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/cover_photo{$ext}?" . current_time( 'timestamp' );
-    }
+	if ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo{$ext}" ) ) {
+		$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/cover_photo{$ext}?" . current_time( 'timestamp' );
+	}
 
-    if ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}{$ext}" ) ) {
-        $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/cover_photo-{$attrs}{$ext}?" . current_time( 'timestamp' );
-    }elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}x{$height}{$ext}" ) ) {
-        $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/cover_photo-{$attrs}x{$height}{$ext}?". current_time( 'timestamp' );
-    }
+	if ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}{$ext}" ) ) {
+		$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/cover_photo-{$attrs}{$ext}?" . current_time( 'timestamp' );
+	}elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "cover_photo-{$attrs}x{$height}{$ext}" ) ) {
+		$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/cover_photo-{$attrs}x{$height}{$ext}?". current_time( 'timestamp' );
+	}
 
-    if ( ! empty( $uri_common ) && empty( $uri ) ) {
-        $uri = $uri_common;
-    }
+	if ( ! empty( $uri_common ) && empty( $uri ) ) {
+		$uri = $uri_common;
+	}
 
-    return $uri;
+	return $uri;
 }
 
 
@@ -1990,9 +1990,9 @@ function um_get_cover_uri( $image, $attrs ) {
  * @return mixed
  */
 function um_get_avatar_url( $get_avatar ) {
-    preg_match( '/src="(.*?)"/i', $get_avatar, $matches );
+	preg_match( '/src="(.*?)"/i', $get_avatar, $matches );
 
-    return isset( $matches[1] ) ? $matches[1] : '';
+	return isset( $matches[1] ) ? $matches[1] : '';
 }
 
 
@@ -2005,92 +2005,92 @@ function um_get_avatar_url( $get_avatar ) {
  * @return bool|string
  */
 function um_get_avatar_uri( $image, $attrs ) {
-    $uri = false;
-    $uri_common = false;
-    $find = false;
-    $ext = '.' . pathinfo( $image, PATHINFO_EXTENSION );
+	$uri = false;
+	$uri_common = false;
+	$find = false;
+	$ext = '.' . pathinfo( $image, PATHINFO_EXTENSION );
 
-    if ( is_multisite() ) {
-        //multisite fix for old customers
-        $multisite_fix_dir = UM()->uploader()->get_upload_base_dir();
-        $multisite_fix_url = UM()->uploader()->get_upload_base_url();
-        $multisite_fix_dir = str_replace( DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . get_current_blog_id() . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, $multisite_fix_dir );
-        $multisite_fix_url = str_replace( '/sites/' . get_current_blog_id() . '/', '/', $multisite_fix_url );
+	if ( is_multisite() ) {
+		//multisite fix for old customers
+		$multisite_fix_dir = UM()->uploader()->get_upload_base_dir();
+		$multisite_fix_url = UM()->uploader()->get_upload_base_url();
+		$multisite_fix_dir = str_replace( DIRECTORY_SEPARATOR . 'sites' . DIRECTORY_SEPARATOR . get_current_blog_id() . DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR, $multisite_fix_dir );
+		$multisite_fix_url = str_replace( '/sites/' . get_current_blog_id() . '/', '/', $multisite_fix_url );
 
-        if ( $attrs == 'original' && file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
-            $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo{$ext}";
-        } elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}x{$attrs}{$ext}" ) ) {
-            $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$attrs}x{$attrs}{$ext}";
-        } elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}{$ext}" ) ) {
-            $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$attrs}{$ext}";
-        } else {
-            $sizes = UM()->options()->get( 'photo_thumb_sizes' );
-            if ( is_array( $sizes ) ) {
-                $find = um_closest_num( $sizes, $attrs );
-            }
+		if ( $attrs == 'original' && file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
+			$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo{$ext}";
+		} elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}x{$attrs}{$ext}" ) ) {
+			$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$attrs}x{$attrs}{$ext}";
+		} elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}{$ext}" ) ) {
+			$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$attrs}{$ext}";
+		} else {
+			$sizes = UM()->options()->get( 'photo_thumb_sizes' );
+			if ( is_array( $sizes ) ) {
+				$find = um_closest_num( $sizes, $attrs );
+			}
 
-            if ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}x{$find}{$ext}" ) ) {
-                $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$find}x{$find}{$ext}";
-            } elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}{$ext}" ) ) {
-                $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$find}{$ext}";
-            } elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
-                $uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo{$ext}";
-            }
-        }
-    }
+			if ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}x{$find}{$ext}" ) ) {
+				$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$find}x{$find}{$ext}";
+			} elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}{$ext}" ) ) {
+				$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo-{$find}{$ext}";
+			} elseif ( file_exists( $multisite_fix_dir . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
+				$uri_common = $multisite_fix_url . um_user( 'ID' ) . "/profile_photo{$ext}";
+			}
+		}
+	}
 
-    if ( $attrs == 'original' && file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
-        $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo{$ext}";
-    } elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}x{$attrs}{$ext}" ) ) {
-        $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$attrs}x{$attrs}{$ext}";
-    } elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}{$ext}" ) ) {
-        $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$attrs}{$ext}";
-    } else {
-        $sizes = UM()->options()->get( 'photo_thumb_sizes' );
-        if ( is_array( $sizes ) ) {
-            $find = um_closest_num( $sizes, $attrs );
-        }
+	if ( $attrs == 'original' && file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
+		$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo{$ext}";
+	} elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}x{$attrs}{$ext}" ) ) {
+		$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$attrs}x{$attrs}{$ext}";
+	} elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$attrs}{$ext}" ) ) {
+		$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$attrs}{$ext}";
+	} else {
+		$sizes = UM()->options()->get( 'photo_thumb_sizes' );
+		if ( is_array( $sizes ) ) {
+			$find = um_closest_num( $sizes, $attrs );
+		}
 
-        if ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}x{$find}{$ext}" ) ) {
-            $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$find}x{$find}{$ext}";
-        } elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}{$ext}" ) ) {
-            $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$find}{$ext}";
-        } elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
-            $uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo{$ext}";
-        }
-    }
+		if ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}x{$find}{$ext}" ) ) {
+			$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$find}x{$find}{$ext}";
+		} elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo-{$find}{$ext}" ) ) {
+			$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo-{$find}{$ext}";
+		} elseif ( file_exists( UM()->uploader()->get_upload_base_dir() . um_user( 'ID' ) . DIRECTORY_SEPARATOR . "profile_photo{$ext}" ) ) {
+			$uri = UM()->uploader()->get_upload_base_url() . um_user( 'ID' ) . "/profile_photo{$ext}";
+		}
+	}
 
-    if ( ! empty( $uri_common ) && empty( $uri ) ) {
-        $uri = $uri_common;
-    }
+	if ( ! empty( $uri_common ) && empty( $uri ) ) {
+		$uri = $uri_common;
+	}
 
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_filter_avatar_cache_time
-     * @description Change Profile field value if it's empty
-     * @input_vars
-     * [{"var":"$timestamp","type":"timestamp","desc":"Avatar cache time"},
-     * {"var":"$user_id","type":"int","desc":"User ID"}]
-     * @change_log
-     * ["Since: 2.0"]
-     * @usage add_filter( 'um_filter_avatar_cache_time', 'function_name', 10, 2 );
-     * @example
-     * <?php
-     * add_filter( 'um_filter_avatar_cache_time', 'my_avatar_cache_time', 10, 2 );
-     * function my_avatar_cache_time( $timestamp, $user_id ) {
-     *     // your code here
-     *     return $timestamp;
-     * }
-     * ?>
-     */
-    $cache_time = apply_filters( 'um_filter_avatar_cache_time', current_time( 'timestamp' ), um_user( 'ID' ) );
-    if ( ! empty( $cache_time ) ) {
-        $uri .= "?{$cache_time}";
-    }
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_filter_avatar_cache_time
+	 * @description Change Profile field value if it's empty
+	 * @input_vars
+	 * [{"var":"$timestamp","type":"timestamp","desc":"Avatar cache time"},
+	 * {"var":"$user_id","type":"int","desc":"User ID"}]
+	 * @change_log
+	 * ["Since: 2.0"]
+	 * @usage add_filter( 'um_filter_avatar_cache_time', 'function_name', 10, 2 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_filter_avatar_cache_time', 'my_avatar_cache_time', 10, 2 );
+	 * function my_avatar_cache_time( $timestamp, $user_id ) {
+	 *     // your code here
+	 *     return $timestamp;
+	 * }
+	 * ?>
+	 */
+	$cache_time = apply_filters( 'um_filter_avatar_cache_time', current_time( 'timestamp' ), um_user( 'ID' ) );
+	if ( ! empty( $cache_time ) ) {
+		$uri .= "?{$cache_time}";
+	}
 
-    return $uri;
+	return $uri;
 }
 
 
@@ -2100,13 +2100,13 @@ function um_get_avatar_uri( $image, $attrs ) {
  * @return string
  */
 function um_get_default_avatar_uri() {
-    $uri = UM()->options()->get( 'default_avatar' );
-    $uri = !empty( $uri['url'] ) ? $uri['url'] : '';
-    if ( ! $uri ) {
-        $uri = um_url . 'assets/img/default_avatar.jpg';
-    }
+	$uri = UM()->options()->get( 'default_avatar' );
+	$uri = !empty( $uri['url'] ) ? $uri['url'] : '';
+	if ( ! $uri ) {
+		$uri = um_url . 'assets/img/default_avatar.jpg';
+	}
 
-    return set_url_scheme( $uri );
+	return set_url_scheme( $uri );
 }
 
 
@@ -2119,105 +2119,105 @@ function um_get_default_avatar_uri() {
  * @return bool|string
  */
 function um_get_user_avatar_data( $user_id = '', $size = '96' ) {
-    if( empty( $user_id ) ) {
-        $user_id = um_user( 'ID' );
-    } else {
-        um_fetch_user( $user_id );
-    }
+	if( empty( $user_id ) ) {
+		$user_id = um_user( 'ID' );
+	} else {
+		um_fetch_user( $user_id );
+	}
 
-    $data = array(
-        'user_id'   => $user_id,
-        'default'   => um_get_default_avatar_uri(),
-        'class'     => 'gravatar avatar avatar-' . $size . ' um-avatar',
-        'size'      => $size
-    );
+	$data = array(
+		'user_id'   => $user_id,
+		'default'   => um_get_default_avatar_uri(),
+		'class'     => 'gravatar avatar avatar-' . $size . ' um-avatar',
+		'size'      => $size
+	);
 
-    if ( $profile_photo = um_profile( 'profile_photo' ) ) {
-        $data['url'] = um_get_avatar_uri( $profile_photo, $size );
-        $data['type'] = 'upload';
-        $data['class'] .= ' um-avatar-uploaded';
-    } elseif ( $synced_profile_photo = um_user( 'synced_profile_photo' ) ) {
-        $data['url'] = $synced_profile_photo;
-        $data['type'] = 'sync';
-        $data['class'] .= ' um-avatar-default';
-    } elseif ( UM()->options()->get( 'use_gravatars' ) ) {
-        $avatar_hash_id = md5( um_user( 'user_email' ) );
-        $data['url'] = set_url_scheme( '//gravatar.com/avatar/' . $avatar_hash_id );
-        $data['url'] = add_query_arg( 's', 400, $data['url'] );
-        $rating = get_option( 'avatar_rating' );
-        if ( ! empty( $rating ) ) {
-            $data['url'] = add_query_arg( 'r', $rating, $data['url'] );
-        }
+	if ( $profile_photo = um_profile( 'profile_photo' ) ) {
+		$data['url'] = um_get_avatar_uri( $profile_photo, $size );
+		$data['type'] = 'upload';
+		$data['class'] .= ' um-avatar-uploaded';
+	} elseif ( $synced_profile_photo = um_user( 'synced_profile_photo' ) ) {
+		$data['url'] = $synced_profile_photo;
+		$data['type'] = 'sync';
+		$data['class'] .= ' um-avatar-default';
+	} elseif ( UM()->options()->get( 'use_gravatars' ) ) {
+		$avatar_hash_id = md5( um_user( 'user_email' ) );
+		$data['url'] = set_url_scheme( '//gravatar.com/avatar/' . $avatar_hash_id );
+		$data['url'] = add_query_arg( 's', 400, $data['url'] );
+		$rating = get_option( 'avatar_rating' );
+		if ( ! empty( $rating ) ) {
+			$data['url'] = add_query_arg( 'r', $rating, $data['url'] );
+		}
 
-        $gravatar_type = UM()->options()->get( 'use_um_gravatar_default_builtin_image' );
-        if ( $gravatar_type == 'default' ) {
-            if ( UM()->options()->get( 'use_um_gravatar_default_image' ) ) {
-                $data['url'] = add_query_arg( 'd', $data['default'], $data['url'] );
-            } else {
-                $default = get_option( 'avatar_default', 'mystery' );
-                if ( $default == 'gravatar_default' ) {
-                    $default = '';
-                }
-                $data['url'] = add_query_arg( 'd', $default, $data['url'] );
-            }
-        } else {
-            $data['url'] = add_query_arg( 'd', $gravatar_type, $data['url'] );
-        }
+		$gravatar_type = UM()->options()->get( 'use_um_gravatar_default_builtin_image' );
+		if ( $gravatar_type == 'default' ) {
+			if ( UM()->options()->get( 'use_um_gravatar_default_image' ) ) {
+				$data['url'] = add_query_arg( 'd', $data['default'], $data['url'] );
+			} else {
+				$default = get_option( 'avatar_default', 'mystery' );
+				if ( $default == 'gravatar_default' ) {
+					$default = '';
+				}
+				$data['url'] = add_query_arg( 'd', $default, $data['url'] );
+			}
+		} else {
+			$data['url'] = add_query_arg( 'd', $gravatar_type, $data['url'] );
+		}
 
-        $data['type'] = 'gravatar';
-        $data['class'] .= ' um-avatar-gravatar';
-    } else {
-        $data['url'] = $data['default'];
-        $data['type'] = 'default';
-        $data['class'] .= ' um-avatar-default';
-    }
+		$data['type'] = 'gravatar';
+		$data['class'] .= ' um-avatar-gravatar';
+	} else {
+		$data['url'] = $data['default'];
+		$data['type'] = 'default';
+		$data['class'] .= ' um-avatar-default';
+	}
 
 
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_user_avatar_url_filter
-     * @description Change user avatar URL
-     * @input_vars
-     * [{"var":"$avatar_uri","type":"string","desc":"Avatar URL"},
-     * {"var":"$user_id","type":"int","desc":"User ID"}]
-     * @change_log
-     * ["Since: 2.0"]
-     * @usage add_filter( 'um_user_avatar_url_filter', 'function_name', 10, 2 );
-     * @example
-     * <?php
-     * add_filter( 'um_user_avatar_url_filter', 'my_user_avatar_url', 10, 2 );
-     * function my_user_avatar_url( $avatar_uri ) {
-     *     // your code here
-     *     return $avatar_uri;
-     * }
-     * ?>
-     */
-    $data['url'] = apply_filters( 'um_user_avatar_url_filter', $data['url'], $user_id, $data );
-    /**
-     * UM hook
-     *
-     * @type filter
-     * @title um_avatar_image_alternate_text
-     * @description Change user display name on um_user function profile photo
-     * @input_vars
-     * [{"var":"$display_name","type":"string","desc":"User Display Name"}]
-     * @change_log
-     * ["Since: 2.0"]
-     * @usage add_filter( 'um_avatar_image_alternate_text', 'function_name', 10, 1 );
-     * @example
-     * <?php
-     * add_filter( 'um_avatar_image_alternate_text', 'my_avatar_image_alternate_text', 10, 1 );
-     * function my_avatar_image_alternate_text( $display_name ) {
-     *     // your code here
-     *     return $display_name;
-     * }
-     * ?>
-     */
-    $data['alt'] = apply_filters( "um_avatar_image_alternate_text", um_user( "display_name" ), $data );
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_user_avatar_url_filter
+	 * @description Change user avatar URL
+	 * @input_vars
+	 * [{"var":"$avatar_uri","type":"string","desc":"Avatar URL"},
+	 * {"var":"$user_id","type":"int","desc":"User ID"}]
+	 * @change_log
+	 * ["Since: 2.0"]
+	 * @usage add_filter( 'um_user_avatar_url_filter', 'function_name', 10, 2 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_user_avatar_url_filter', 'my_user_avatar_url', 10, 2 );
+	 * function my_user_avatar_url( $avatar_uri ) {
+	 *     // your code here
+	 *     return $avatar_uri;
+	 * }
+	 * ?>
+	 */
+	$data['url'] = apply_filters( 'um_user_avatar_url_filter', $data['url'], $user_id, $data );
+	/**
+	 * UM hook
+	 *
+	 * @type filter
+	 * @title um_avatar_image_alternate_text
+	 * @description Change user display name on um_user function profile photo
+	 * @input_vars
+	 * [{"var":"$display_name","type":"string","desc":"User Display Name"}]
+	 * @change_log
+	 * ["Since: 2.0"]
+	 * @usage add_filter( 'um_avatar_image_alternate_text', 'function_name', 10, 1 );
+	 * @example
+	 * <?php
+	 * add_filter( 'um_avatar_image_alternate_text', 'my_avatar_image_alternate_text', 10, 1 );
+	 * function my_avatar_image_alternate_text( $display_name ) {
+	 *     // your code here
+	 *     return $display_name;
+	 * }
+	 * ?>
+	 */
+	$data['alt'] = apply_filters( "um_avatar_image_alternate_text", um_user( "display_name" ), $data );
 
-    return $data;
+	return $data;
 }
 
 
@@ -2230,8 +2230,8 @@ function um_get_user_avatar_data( $user_id = '', $size = '96' ) {
  * @return bool|string
  */
 function um_get_user_avatar_url( $user_id = '', $size = '96' ) {
-    $data = um_get_user_avatar_data( $user_id, $size );
-    return $data['url'];
+	$data = um_get_user_avatar_data( $user_id, $size );
+	return $data['url'];
 }
 
 
@@ -2241,34 +2241,34 @@ function um_get_user_avatar_url( $user_id = '', $size = '96' ) {
  * @return mixed|string|void
  */
 function um_get_default_cover_uri() {
-    $uri = UM()->options()->get( 'default_cover' );
-    $uri = ! empty( $uri['url'] ) ? $uri['url'] : '';
-    if ( $uri ) {
+	$uri = UM()->options()->get( 'default_cover' );
+	$uri = ! empty( $uri['url'] ) ? $uri['url'] : '';
+	if ( $uri ) {
 
-        /**
-         * UM hook
-         *
-         * @type filter
-         * @title um_get_default_cover_uri_filter
-         * @description Change Default Cover URL
-         * @input_vars
-         * [{"var":"$uri","type":"string","desc":"Default Cover URL"}]
-         * @change_log
-         * ["Since: 2.0"]
-         * @usage add_filter( 'um_get_default_cover_uri_filter', 'function_name', 10, 1 );
-         * @example
-         * <?php
-         * add_filter( 'um_get_default_cover_uri_filter', 'my_default_cover_uri', 10, 1 );
-         * function my_default_cover_uri( $uri ) {
-         *     // your code here
-         *     return $uri;
-         * }
-         * ?>
-         */
-        return apply_filters( 'um_get_default_cover_uri_filter', $uri );
-    }
+		/**
+		 * UM hook
+		 *
+		 * @type filter
+		 * @title um_get_default_cover_uri_filter
+		 * @description Change Default Cover URL
+		 * @input_vars
+		 * [{"var":"$uri","type":"string","desc":"Default Cover URL"}]
+		 * @change_log
+		 * ["Since: 2.0"]
+		 * @usage add_filter( 'um_get_default_cover_uri_filter', 'function_name', 10, 1 );
+		 * @example
+		 * <?php
+		 * add_filter( 'um_get_default_cover_uri_filter', 'my_default_cover_uri', 10, 1 );
+		 * function my_default_cover_uri( $uri ) {
+		 *     // your code here
+		 *     return $uri;
+		 * }
+		 * ?>
+		 */
+		return apply_filters( 'um_get_default_cover_uri_filter', $uri );
+	}
 
-    return '';
+	return '';
 }
 
 
@@ -2280,327 +2280,327 @@ function um_get_default_cover_uri() {
  */
 function um_user( $data, $attrs = null ) {
 
-    switch ($data) {
+	switch ($data) {
 
-        default:
+		default:
 
-            $value = um_profile( $data );
+			$value = um_profile( $data );
 
-            $value = maybe_unserialize( $value );
+			$value = maybe_unserialize( $value );
 
-            if ( in_array( $data, array( 'role', 'gender' ) ) ) {
-                if ( is_array( $value ) ) {
-                    $value = implode( ",", $value );
-                }
+			if ( in_array( $data, array( 'role', 'gender' ) ) ) {
+				if ( is_array( $value ) ) {
+					$value = implode( ",", $value );
+				}
 
-                return $value;
-            }
+				return $value;
+			}
 
-            return $value;
-            break;
+			return $value;
+			break;
 
-        case 'user_email':
+		case 'user_email':
 
-            $user_email_in_meta = get_user_meta( um_user( 'ID' ), 'user_email', true );
-            if ( $user_email_in_meta ) {
-                delete_user_meta( um_user( 'ID' ), 'user_email' );
-            }
+			$user_email_in_meta = get_user_meta( um_user( 'ID' ), 'user_email', true );
+			if ( $user_email_in_meta ) {
+				delete_user_meta( um_user( 'ID' ), 'user_email' );
+			}
 
-            $value = um_profile( $data );
+			$value = um_profile( $data );
 
-            return $value;
-            break;
+			return $value;
+			break;
 
-        case 'user_login':
+		case 'user_login':
 
-            $user_login_in_meta = get_user_meta( um_user( 'ID' ), 'user_login', true );
-            if ( $user_login_in_meta ) {
-                delete_user_meta( um_user( 'ID' ), 'user_login' );
-            }
+			$user_login_in_meta = get_user_meta( um_user( 'ID' ), 'user_login', true );
+			if ( $user_login_in_meta ) {
+				delete_user_meta( um_user( 'ID' ), 'user_login' );
+			}
 
-            $value = um_profile( $data );
+			$value = um_profile( $data );
 
-            return $value;
-            break;
+			return $value;
+			break;
 
-        case 'first_name':
-        case 'last_name':
+		case 'first_name':
+		case 'last_name':
 
-            $name = um_profile( $data );
+			$name = um_profile( $data );
 
-            if ( UM()->options()->get( 'force_display_name_capitlized' ) ) {
-                $name = implode( '-', array_map( 'ucfirst', explode( '-', $name ) ) );
-            }
+			if ( UM()->options()->get( 'force_display_name_capitlized' ) ) {
+				$name = implode( '-', array_map( 'ucfirst', explode( '-', $name ) ) );
+			}
 
-            /**
-             * UM hook
-             *
-             * @type filter
-             * @title um_user_{$data}_case
-             * @description Change user name on um_user function
-             * @input_vars
-             * [{"var":"$name","type":"string","desc":"User Name"}]
-             * @change_log
-             * ["Since: 2.0"]
-             * @usage add_filter( 'um_user_{$data}_case', 'function_name', 10, 1 );
-             * @example
-             * <?php
-             * add_filter( 'um_user_{$data}_case', 'my_user_case', 10, 1 );
-             * function my_user_case( $name ) {
-             *     // your code here
-             *     return $name;
-             * }
-             * ?>
-             */
-            $name = apply_filters( "um_user_{$data}_case", $name );
-
-            return $name;
+			/**
+			 * UM hook
+			 *
+			 * @type filter
+			 * @title um_user_{$data}_case
+			 * @description Change user name on um_user function
+			 * @input_vars
+			 * [{"var":"$name","type":"string","desc":"User Name"}]
+			 * @change_log
+			 * ["Since: 2.0"]
+			 * @usage add_filter( 'um_user_{$data}_case', 'function_name', 10, 1 );
+			 * @example
+			 * <?php
+			 * add_filter( 'um_user_{$data}_case', 'my_user_case', 10, 1 );
+			 * function my_user_case( $name ) {
+			 *     // your code here
+			 *     return $name;
+			 * }
+			 * ?>
+			 */
+			$name = apply_filters( "um_user_{$data}_case", $name );
+
+			return $name;
 
-            break;
-
-        case 'full_name':
-
-            if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
-                $full_name = um_user( 'first_name' ) . ' ' . um_user( 'last_name' );
-            } else {
-                $full_name = um_user( 'display_name' );
-            }
-
-            $full_name = UM()->validation()->safe_name_in_url( $full_name );
-
-            // update full_name changed
-            if ( um_profile( $data ) !== $full_name ) {
-                update_user_meta( um_user( 'ID' ), 'full_name', $full_name );
-            }
-
-            return $full_name;
-
-            break;
-
-        case 'first_and_last_name_initial':
-
-            $f_and_l_initial = '';
-
-            if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
-                $initial = um_user( 'last_name' );
-                $f_and_l_initial = um_user( 'first_name' ) . ' ' . $initial[0];
-            } else {
-                $f_and_l_initial = um_profile( $data );
-            }
-
-            $f_and_l_initial = UM()->validation()->safe_name_in_url( $f_and_l_initial );
-
-            if ( UM()->options()->get( 'force_display_name_capitlized' ) ) {
-                $name = implode( '-', array_map( 'ucfirst', explode( '-', $f_and_l_initial ) ) );
-            } else {
-                $name = $f_and_l_initial;
-            }
-
-            return $name;
-
-            break;
-
-        case 'display_name':
-
-            $op = UM()->options()->get( 'display_name' );
-
-            $name = '';
-
-            if ( $op == 'default' ) {
-                $name = um_profile( 'display_name' );
-            }
-
-            if ( $op == 'nickname' ) {
-                $name = um_profile( 'nickname' );
-            }
-
-            if ( $op == 'full_name' ) {
-                if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
-                    $name = um_user( 'first_name' ) . ' ' . um_user( 'last_name' );
-                } else {
-                    $name = um_profile( $data );
-                }
-                if ( ! $name ) {
-                    $name = um_user( 'user_login' );
-                }
-            }
-
-            if ( $op == 'sur_name' ) {
-                if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
-                    $name = um_user( 'last_name' ) . ' ' . um_user( 'first_name' );
-                } else {
-                    $name = um_profile( $data );
-                }
-            }
-
-            if ( $op == 'first_name' ) {
-                if ( um_user( 'first_name' ) ) {
-                    $name = um_user( 'first_name' );
-                } else {
-                    $name = um_profile( $data );
-                }
-            }
-
-            if ( $op == 'username' ) {
-                $name = um_user( 'user_login' );
-            }
-
-            if ( $op == 'initial_name' ) {
-                if (um_user( 'first_name' ) && um_user( 'last_name' )) {
-                    $initial = um_user( 'last_name' );
-                    $name = um_user( 'first_name' ) . ' ' . $initial[0];
-                } else {
-                    $name = um_profile( $data );
-                }
-            }
-
-            if ( $op == 'initial_name_f' ) {
-                if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
-                    $initial = um_user( 'first_name' );
-                    $name = $initial[0] . ' ' . um_user( 'last_name' );
-                } else {
-                    $name = um_profile( $data );
-                }
-            }
-
-
-            if ( $op == 'field' && UM()->options()->get( 'display_name_field' ) != '' ) {
-                $fields = array_filter( preg_split( '/[,\s]+/', UM()->options()->get( 'display_name_field' ) ) );
-                $name = '';
-
-                foreach ( $fields as $field ) {
-                    if ( um_profile( $field ) ) {
-                        $name .= um_profile( $field ) . ' ';
-                    } elseif ( um_user( $field ) && $field != 'display_name' && $field != 'full_name' ) {
-                        $name .= um_user( $field ) . ' ';
-                    }
-                }
-            }
-
-            if ( UM()->options()->get( 'force_display_name_capitlized' ) ) {
-                $name = implode( '-', array_map( 'ucfirst', explode( '-', $name ) ) );
-            }
-
-            /**
-             * UM hook
-             *
-             * @type filter
-             * @title um_user_display_name_filter
-             * @description Change user display name on um_user function
-             * @input_vars
-             * [{"var":"$name","type":"string","desc":"User Name"},
-             * {"var":"$user_id","type":"int","desc":"User ID"},
-             * {"var":"$html","type":"bool","desc":"Is HTML"}]
-             * @change_log
-             * ["Since: 2.0"]
-             * @usage add_filter( 'um_user_display_name_filter', 'function_name', 10, 3 );
-             * @example
-             * <?php
-             * add_filter( 'um_user_display_name_filter', 'my_user_display_name', 10, 3 );
-             * function my_user_display_name( $name, $user_id, $html ) {
-             *     // your code here
-             *     return $name;
-             * }
-             * ?>
-             */
-            return apply_filters( 'um_user_display_name_filter', $name, um_user( 'ID' ), ( $attrs == 'html' ) ? 1 : 0 );
-
-            break;
-
-        case 'role_select':
-        case 'role_radio':
-
-            return UM()->roles()->get_role_name( UM()->roles()->get_editable_priority_user_role( um_user( 'ID' ) ) );
-            break;
-
-        case 'submitted':
-            $array = um_profile( $data );
-            if ( empty( $array ) ) {
-                return '';
-            }
-            $array = maybe_unserialize( $array );
-
-            return $array;
-            break;
-
-        case 'password_reset_link':
-            return UM()->password()->reset_url();
-            break;
-
-        case 'account_activation_link':
-            return UM()->permalinks()->activate_url();
-            break;
-
-        case 'profile_photo':
-            $data = um_get_user_avatar_data( um_user( 'ID' ), $attrs );
-
-            return sprintf( '<img src="%s" class="%s" width="%s" height="%s" alt="%s" data-default="%s" onerror="%s" />',
-                esc_attr( $data['url'] ),
-                esc_attr( $data['class'] ),
-                esc_attr( $data['size'] ),
-                esc_attr( $data['size'] ),
-                esc_attr( $data['alt'] ),
-                esc_attr( $data['default'] ),
-                'if ( ! this.getAttribute(\'data-load-error\') ){ this.setAttribute(\'data-load-error\', \'1\');this.setAttribute(\'src\', this.getAttribute(\'data-default\'));}'
-            );
-            break;
-
-        case 'cover_photo':
-
-            $is_default = false;
-
-            if ( um_profile( 'cover_photo' ) ) {
-                $cover_uri = um_get_cover_uri( um_profile( 'cover_photo' ), $attrs );
-            } elseif ( um_profile( 'synced_cover_photo' ) ) {
-                $cover_uri = um_profile( 'synced_cover_photo' );
-            } else {
-                $cover_uri = um_get_default_cover_uri();
-                $is_default = true;
-            }
-
-            /**
-             * UM hook
-             *
-             * @type filter
-             * @title um_user_cover_photo_uri__filter
-             * @description Change user avatar URL
-             * @input_vars
-             * [{"var":"$cover_uri","type":"string","desc":"Cover URL"},
-             * {"var":"$is_default","type":"bool","desc":"Default or not"},
-             * {"var":"$attrs","type":"array","desc":"Attributes"}]
-             * @change_log
-             * ["Since: 2.0"]
-             * @usage add_filter( 'um_user_cover_photo_uri__filter', 'function_name', 10, 3 );
-             * @example
-             * <?php
-             * add_filter( 'um_user_cover_photo_uri__filter', 'my_user_cover_photo_uri', 10, 3 );
-             * function my_user_cover_photo_uri( $cover_uri, $is_default, $attrs ) {
-             *     // your code here
-             *     return $cover_uri;
-             * }
-             * ?>
-             */
-            $cover_uri = apply_filters( 'um_user_cover_photo_uri__filter', $cover_uri, $is_default, $attrs );
-
-            $alt = um_profile( 'nickname' );
-
-            $cover_html = $cover_uri ? '<img src="' . esc_attr( $cover_uri ) . '" alt="' . esc_attr( $alt ) . '" />' : '';
-
-            $cover_html = apply_filters( 'um_user_cover_photo_html__filter', $cover_html, $cover_uri, $alt, $is_default, $attrs );
-            return $cover_html;
-
-            break;
-
-        case 'user_url':
-
-            $value = um_profile( $data );
-
-            return $value;
-
-            break;
-
-
-    }
+			break;
+
+		case 'full_name':
+
+			if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
+				$full_name = um_user( 'first_name' ) . ' ' . um_user( 'last_name' );
+			} else {
+				$full_name = um_user( 'display_name' );
+			}
+
+			$full_name = UM()->validation()->safe_name_in_url( $full_name );
+
+			// update full_name changed
+			if ( um_profile( $data ) !== $full_name ) {
+				update_user_meta( um_user( 'ID' ), 'full_name', $full_name );
+			}
+
+			return $full_name;
+
+			break;
+
+		case 'first_and_last_name_initial':
+
+			$f_and_l_initial = '';
+
+			if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
+				$initial = um_user( 'last_name' );
+				$f_and_l_initial = um_user( 'first_name' ) . ' ' . $initial[0];
+			} else {
+				$f_and_l_initial = um_profile( $data );
+			}
+
+			$f_and_l_initial = UM()->validation()->safe_name_in_url( $f_and_l_initial );
+
+			if ( UM()->options()->get( 'force_display_name_capitlized' ) ) {
+				$name = implode( '-', array_map( 'ucfirst', explode( '-', $f_and_l_initial ) ) );
+			} else {
+				$name = $f_and_l_initial;
+			}
+
+			return $name;
+
+			break;
+
+		case 'display_name':
+
+			$op = UM()->options()->get( 'display_name' );
+
+			$name = '';
+
+			if ( $op == 'default' ) {
+				$name = um_profile( 'display_name' );
+			}
+
+			if ( $op == 'nickname' ) {
+				$name = um_profile( 'nickname' );
+			}
+
+			if ( $op == 'full_name' ) {
+				if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
+					$name = um_user( 'first_name' ) . ' ' . um_user( 'last_name' );
+				} else {
+					$name = um_profile( $data );
+				}
+				if ( ! $name ) {
+					$name = um_user( 'user_login' );
+				}
+			}
+
+			if ( $op == 'sur_name' ) {
+				if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
+					$name = um_user( 'last_name' ) . ' ' . um_user( 'first_name' );
+				} else {
+					$name = um_profile( $data );
+				}
+			}
+
+			if ( $op == 'first_name' ) {
+				if ( um_user( 'first_name' ) ) {
+					$name = um_user( 'first_name' );
+				} else {
+					$name = um_profile( $data );
+				}
+			}
+
+			if ( $op == 'username' ) {
+				$name = um_user( 'user_login' );
+			}
+
+			if ( $op == 'initial_name' ) {
+				if (um_user( 'first_name' ) && um_user( 'last_name' )) {
+					$initial = um_user( 'last_name' );
+					$name = um_user( 'first_name' ) . ' ' . $initial[0];
+				} else {
+					$name = um_profile( $data );
+				}
+			}
+
+			if ( $op == 'initial_name_f' ) {
+				if ( um_user( 'first_name' ) && um_user( 'last_name' ) ) {
+					$initial = um_user( 'first_name' );
+					$name = $initial[0] . ' ' . um_user( 'last_name' );
+				} else {
+					$name = um_profile( $data );
+				}
+			}
+
+
+			if ( $op == 'field' && UM()->options()->get( 'display_name_field' ) != '' ) {
+				$fields = array_filter( preg_split( '/[,\s]+/', UM()->options()->get( 'display_name_field' ) ) );
+				$name = '';
+
+				foreach ( $fields as $field ) {
+					if ( um_profile( $field ) ) {
+						$name .= um_profile( $field ) . ' ';
+					} elseif ( um_user( $field ) && $field != 'display_name' && $field != 'full_name' ) {
+						$name .= um_user( $field ) . ' ';
+					}
+				}
+			}
+
+			if ( UM()->options()->get( 'force_display_name_capitlized' ) ) {
+				$name = implode( '-', array_map( 'ucfirst', explode( '-', $name ) ) );
+			}
+
+			/**
+			 * UM hook
+			 *
+			 * @type filter
+			 * @title um_user_display_name_filter
+			 * @description Change user display name on um_user function
+			 * @input_vars
+			 * [{"var":"$name","type":"string","desc":"User Name"},
+			 * {"var":"$user_id","type":"int","desc":"User ID"},
+			 * {"var":"$html","type":"bool","desc":"Is HTML"}]
+			 * @change_log
+			 * ["Since: 2.0"]
+			 * @usage add_filter( 'um_user_display_name_filter', 'function_name', 10, 3 );
+			 * @example
+			 * <?php
+			 * add_filter( 'um_user_display_name_filter', 'my_user_display_name', 10, 3 );
+			 * function my_user_display_name( $name, $user_id, $html ) {
+			 *     // your code here
+			 *     return $name;
+			 * }
+			 * ?>
+			 */
+			return apply_filters( 'um_user_display_name_filter', $name, um_user( 'ID' ), ( $attrs == 'html' ) ? 1 : 0 );
+
+			break;
+
+		case 'role_select':
+		case 'role_radio':
+
+			return UM()->roles()->get_role_name( UM()->roles()->get_editable_priority_user_role( um_user( 'ID' ) ) );
+			break;
+
+		case 'submitted':
+			$array = um_profile( $data );
+			if ( empty( $array ) ) {
+				return '';
+			}
+			$array = maybe_unserialize( $array );
+
+			return $array;
+			break;
+
+		case 'password_reset_link':
+			return UM()->password()->reset_url();
+			break;
+
+		case 'account_activation_link':
+			return UM()->permalinks()->activate_url();
+			break;
+
+		case 'profile_photo':
+			$data = um_get_user_avatar_data( um_user( 'ID' ), $attrs );
+
+			return sprintf( '<img src="%s" class="%s" width="%s" height="%s" alt="%s" data-default="%s" onerror="%s" />',
+				esc_attr( $data['url'] ),
+				esc_attr( $data['class'] ),
+				esc_attr( $data['size'] ),
+				esc_attr( $data['size'] ),
+				esc_attr( $data['alt'] ),
+				esc_attr( $data['default'] ),
+				'if ( ! this.getAttribute(\'data-load-error\') ){ this.setAttribute(\'data-load-error\', \'1\');this.setAttribute(\'src\', this.getAttribute(\'data-default\'));}'
+			);
+			break;
+
+		case 'cover_photo':
+
+			$is_default = false;
+
+			if ( um_profile( 'cover_photo' ) ) {
+				$cover_uri = um_get_cover_uri( um_profile( 'cover_photo' ), $attrs );
+			} elseif ( um_profile( 'synced_cover_photo' ) ) {
+				$cover_uri = um_profile( 'synced_cover_photo' );
+			} else {
+				$cover_uri = um_get_default_cover_uri();
+				$is_default = true;
+			}
+
+			/**
+			 * UM hook
+			 *
+			 * @type filter
+			 * @title um_user_cover_photo_uri__filter
+			 * @description Change user avatar URL
+			 * @input_vars
+			 * [{"var":"$cover_uri","type":"string","desc":"Cover URL"},
+			 * {"var":"$is_default","type":"bool","desc":"Default or not"},
+			 * {"var":"$attrs","type":"array","desc":"Attributes"}]
+			 * @change_log
+			 * ["Since: 2.0"]
+			 * @usage add_filter( 'um_user_cover_photo_uri__filter', 'function_name', 10, 3 );
+			 * @example
+			 * <?php
+			 * add_filter( 'um_user_cover_photo_uri__filter', 'my_user_cover_photo_uri', 10, 3 );
+			 * function my_user_cover_photo_uri( $cover_uri, $is_default, $attrs ) {
+			 *     // your code here
+			 *     return $cover_uri;
+			 * }
+			 * ?>
+			 */
+			$cover_uri = apply_filters( 'um_user_cover_photo_uri__filter', $cover_uri, $is_default, $attrs );
+
+			$alt = um_profile( 'nickname' );
+
+			$cover_html = $cover_uri ? '<img src="' . esc_attr( $cover_uri ) . '" alt="' . esc_attr( $alt ) . '" />' : '';
+
+			$cover_html = apply_filters( 'um_user_cover_photo_html__filter', $cover_html, $cover_uri, $alt, $is_default, $attrs );
+			return $cover_html;
+
+			break;
+
+		case 'user_url':
+
+			$value = um_profile( $data );
+
+			return $value;
+
+			break;
+
+
+	}
 
 }
 
@@ -2612,13 +2612,13 @@ function um_user( $data, $attrs = null ) {
  */
 function um_get_domain_protocol() {
 
-    if (is_ssl()) {
-        $protocol = 'https://';
-    } else {
-        $protocol = 'http://';
-    }
+	if (is_ssl()) {
+		$protocol = 'https://';
+	} else {
+		$protocol = 'http://';
+	}
 
-    return $protocol;
+	return $protocol;
 }
 
 
@@ -2631,11 +2631,11 @@ function um_get_domain_protocol() {
  */
 function um_secure_media_uri( $url ) {
 
-    if (is_ssl()) {
-        $url = str_replace( 'http:', 'https:', $url );
-    }
+	if (is_ssl()) {
+		$url = str_replace( 'http:', 'https:', $url );
+	}
 
-    return $url;
+	return $url;
 }
 
 
@@ -2648,30 +2648,30 @@ function um_secure_media_uri( $url ) {
  */
 function um_force_utf8_string( $value ) {
 
-    if (is_array( $value )) {
-        $arr_value = array();
-        foreach ($value as $key => $value) {
-            $utf8_decoded_value = utf8_decode( $value );
+	if (is_array( $value )) {
+		$arr_value = array();
+		foreach ($value as $key => $value) {
+			$utf8_decoded_value = utf8_decode( $value );
 
-            if (mb_check_encoding( $utf8_decoded_value, 'UTF-8' )) {
-                array_push( $arr_value, $utf8_decoded_value );
-            } else {
-                array_push( $arr_value, $value );
-            }
+			if (mb_check_encoding( $utf8_decoded_value, 'UTF-8' )) {
+				array_push( $arr_value, $utf8_decoded_value );
+			} else {
+				array_push( $arr_value, $value );
+			}
 
-        }
+		}
 
-        return $arr_value;
-    } else {
+		return $arr_value;
+	} else {
 
-        $utf8_decoded_value = utf8_decode( $value );
+		$utf8_decoded_value = utf8_decode( $value );
 
-        if (mb_check_encoding( $utf8_decoded_value, 'UTF-8' )) {
-            return $utf8_decoded_value;
-        }
-    }
+		if (mb_check_encoding( $utf8_decoded_value, 'UTF-8' )) {
+			return $utf8_decoded_value;
+		}
+	}
 
-    return $value;
+	return $value;
 }
 
 
@@ -2684,36 +2684,36 @@ function um_force_utf8_string( $value ) {
  * @return mixed string $host if detected, false otherwise
  */
 function um_get_host() {
-    $host = false;
+	$host = false;
 
-    if (defined( 'WPE_APIKEY' )) {
-        $host = 'WP Engine';
-    } else if (defined( 'PAGELYBIN' )) {
-        $host = 'Pagely';
-    } else if (DB_HOST == 'localhost:/tmp/mysql5.sock') {
-        $host = 'ICDSoft';
-    } else if (DB_HOST == 'mysqlv5') {
-        $host = 'NetworkSolutions';
-    } else if (strpos( DB_HOST, 'ipagemysql.com' ) !== false) {
-        $host = 'iPage';
-    } else if (strpos( DB_HOST, 'ipowermysql.com' ) !== false) {
-        $host = 'IPower';
-    } else if (strpos( DB_HOST, '.gridserver.com' ) !== false) {
-        $host = 'MediaTemple Grid';
-    } else if (strpos( DB_HOST, '.pair.com' ) !== false) {
-        $host = 'pair Networks';
-    } else if (strpos( DB_HOST, '.stabletransit.com' ) !== false) {
-        $host = 'Rackspace Cloud';
-    } else if (strpos( DB_HOST, '.sysfix.eu' ) !== false) {
-        $host = 'SysFix.eu Power Hosting';
-    } else if (strpos( $_SERVER['SERVER_NAME'], 'Flywheel' ) !== false) {
-        $host = 'Flywheel';
-    } else {
-        // Adding a general fallback for data gathering
-        $host = 'DBH: ' . DB_HOST . ', SRV: ' . $_SERVER['SERVER_NAME'];
-    }
+	if (defined( 'WPE_APIKEY' )) {
+		$host = 'WP Engine';
+	} else if (defined( 'PAGELYBIN' )) {
+		$host = 'Pagely';
+	} else if (DB_HOST == 'localhost:/tmp/mysql5.sock') {
+		$host = 'ICDSoft';
+	} else if (DB_HOST == 'mysqlv5') {
+		$host = 'NetworkSolutions';
+	} else if (strpos( DB_HOST, 'ipagemysql.com' ) !== false) {
+		$host = 'iPage';
+	} else if (strpos( DB_HOST, 'ipowermysql.com' ) !== false) {
+		$host = 'IPower';
+	} else if (strpos( DB_HOST, '.gridserver.com' ) !== false) {
+		$host = 'MediaTemple Grid';
+	} else if (strpos( DB_HOST, '.pair.com' ) !== false) {
+		$host = 'pair Networks';
+	} else if (strpos( DB_HOST, '.stabletransit.com' ) !== false) {
+		$host = 'Rackspace Cloud';
+	} else if (strpos( DB_HOST, '.sysfix.eu' ) !== false) {
+		$host = 'SysFix.eu Power Hosting';
+	} else if (strpos( $_SERVER['SERVER_NAME'], 'Flywheel' ) !== false) {
+		$host = 'Flywheel';
+	} else {
+		// Adding a general fallback for data gathering
+		$host = 'DBH: ' . DB_HOST . ', SRV: ' . $_SERVER['SERVER_NAME'];
+	}
 
-    return $host;
+	return $host;
 }
 
 
@@ -2730,22 +2730,22 @@ function um_get_host() {
  * @return int|string
  */
 function um_let_to_num( $v ) {
-    $l = substr( $v, -1 );
-    $ret = substr( $v, 0, -1 );
+	$l = substr( $v, -1 );
+	$ret = substr( $v, 0, -1 );
 
-    switch (strtoupper( $l )) {
-        case 'P': // fall-through
-        case 'T': // fall-through
-        case 'G': // fall-through
-        case 'M': // fall-through
-        case 'K': // fall-through
-            $ret *= 1024;
-            break;
-        default:
-            break;
-    }
+	switch (strtoupper( $l )) {
+		case 'P': // fall-through
+		case 'T': // fall-through
+		case 'G': // fall-through
+		case 'M': // fall-through
+		case 'K': // fall-through
+			$ret *= 1024;
+			break;
+		default:
+			break;
+	}
 
-    return $ret;
+	return $ret;
 }
 
 
@@ -2755,12 +2755,12 @@ function um_let_to_num( $v ) {
  * @return bool
  */
 function is_ultimatemember() {
-    global $post;
+	global $post;
 
-    if ( isset( $post->ID ) && in_array( $post->ID, UM()->config()->permalinks ) )
-        return true;
+	if ( isset( $post->ID ) && in_array( $post->ID, UM()->config()->permalinks ) )
+		return true;
 
-    return false;
+	return false;
 }
 
 
@@ -2768,7 +2768,7 @@ function is_ultimatemember() {
  * Maybe set empty time limit
  */
 function um_maybe_unset_time_limit() {
-    @set_time_limit( 0 );
+	@set_time_limit( 0 );
 }
 
 
@@ -2777,22 +2777,22 @@ function um_maybe_unset_time_limit() {
  * @Returns Boolean
 */
 if ( ! function_exists( 'um_is_profile_owner' ) ) {
-    /**
-     * @param $user_id
-     *
-     * @return bool
-     */
-    function um_is_profile_owner( $user_id = false ) {
-        if ( ! is_user_logged_in() ) {
-            return false;
-        }
+	/**
+	 * @param $user_id
+	 *
+	 * @return bool
+	 */
+	function um_is_profile_owner( $user_id = false ) {
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
 
-        if ( empty( $user_id ) ) {
-            $user_id = get_current_user_id();
-        }
+		if ( empty( $user_id ) ) {
+			$user_id = get_current_user_id();
+		}
 
-        return ( $user_id == um_profile_id() );
-    }
+		return ( $user_id == um_profile_id() );
+	}
 }
 
 
@@ -2811,16 +2811,16 @@ if ( ! function_exists( 'um_is_profile_owner' ) ) {
  */
 function um_is_amp( $check_theme_support = true ) {
 
-    $is_amp = false;
+	$is_amp = false;
 
-    if ( ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ||
-        ( function_exists( 'is_better_amp' ) && is_better_amp() ) ) {
-        $is_amp = true;
-    }
+	if ( ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ||
+		( function_exists( 'is_better_amp' ) && is_better_amp() ) ) {
+		$is_amp = true;
+	}
 
-    if ( $is_amp && $check_theme_support ) {
-        $is_amp = current_theme_supports( 'amp' );
-    }
+	if ( $is_amp && $check_theme_support ) {
+		$is_amp = current_theme_supports( 'amp' );
+	}
 
-    return apply_filters( 'um_is_amp', $is_amp );
+	return apply_filters( 'um_is_amp', $is_amp );
 }


### PR DESCRIPTION
Added the ability to filter the um_is_core_page() return value.

Can be useful to take custom pages into account, like polylang UM core page translation.

Usage:

```php
function um_translated_is_core_page( $is_core_page, $page, $post ) {
    // original UM core pages are in french, check if we are on an UM english translation core page
    if( isset( $post->ID ) && function_exists( 'pll_get_post' ) && function_exists( 'pll_current_language' ) ) {
       
        if( pll_current_language() == 'en' ) {
            // get original page
            $fr_post_id = pll_get_post( $post->ID, 'fr' );

            if ( isset( UM()->config()->permalinks[ $page ] ) && $fr_post_id == UM()->config()->permalinks[ $page ] ) {
                $is_core_page = true;
            }
        }
    }

    return $is_core_page;
}
add_filter( 'um_is_core_page_filter', 'um_translated_is_core_page', 10, 3 );
```