### PR TITLE
Indexing of Profiles

### DIFF
--- a/includes/admin/core/class-admin-settings.php
+++ b/includes/admin/core/class-admin-settings.php
@@ -630,6 +630,17 @@ if ( ! class_exists( 'um\admin\core\Admin_Settings' ) ) {
 									'type'      => 'checkbox',
 									'label'     => __( 'Require a strong password? (when user resets password only)', 'ultimate-member' ),
 									'tooltip'   => __( 'Enable or disable a strong password rules on password reset and change procedure', 'ultimate-member' ),
+								),
+								array(
+									'id'        => 'profile_noindex',
+									'type'      => 'select',
+									'size'      => 'small',
+									'label'     => __( 'Avoid indexing profile by search engines', 'ultimate-member' ),
+									'tooltip'   => __( 'Hides the profile page for robots.', 'ultimate-member' ) . ' ' . __( 'This setting can be overridden by individual role settings.', 'ultimate-member' ),
+									'options'   => [
+											'1' => __( 'Yes', 'ultimate-member' ),
+											''  => __( 'No', 'ultimate-member' )
+									]
 								)
 							)
 						),

--- a/includes/admin/templates/role/profile.php
+++ b/includes/admin/templates/role/profile.php
@@ -43,11 +43,17 @@
 			),
 			array(
 				'id'        => '_um_profile_noindex',
-				'type'      => 'checkbox',
+				'type'      => 'select',
+				'size'      => 'medium',
 				'name'      => '_um_profile_noindex',
 				'label'     => __( 'Avoid indexing profile by search engines', 'ultimate-member' ),
-				'tooltip'   => __( 'Hides the profile page for robots', 'ultimate-member' ),
-				'value'     => ! empty( $role['_um_profile_noindex'] ) ? $role['_um_profile_noindex'] : 0,
+				'tooltip'   => __( 'Hides the profile page for robots.', 'ultimate-member' ) . ' ' . __( 'The default value depends on the general users settings.', 'ultimate-member' ),
+				'options'   => [
+						''  => __( 'Default', 'ultimate-member' ),
+						'1' => __( 'Yes', 'ultimate-member' ),
+						'2' => __( 'No', 'ultimate-member' )
+				],
+				'value'     => ! empty( $role['_um_profile_noindex'] ) ? $role['_um_profile_noindex'] : '',
 			)
 		)
 	) )->render_form(); ?>

--- a/includes/admin/templates/role/profile.php
+++ b/includes/admin/templates/role/profile.php
@@ -40,6 +40,14 @@
 				'label'     => __( 'Can view/access private profiles?', 'ultimate-member' ),
 				'tooltip'   => __( 'Can this role view private profiles?', 'ultimate-member' ),
 				'value'     => ! empty( $role['_um_can_access_private_profile'] ) ? $role['_um_can_access_private_profile'] : 0,
+			),
+			array(
+				'id'        => '_um_profile_noindex',
+				'type'      => 'checkbox',
+				'name'      => '_um_profile_noindex',
+				'label'     => __( 'Avoid indexing profile by search engines', 'ultimate-member' ),
+				'tooltip'   => __( 'Hides the profile page for robots', 'ultimate-member' ),
+				'value'     => ! empty( $role['_um_profile_noindex'] ) ? $role['_um_profile_noindex'] : 0,
 			)
 		)
 	) )->render_form(); ?>

--- a/includes/core/class-builtin.php
+++ b/includes/core/class-builtin.php
@@ -1139,7 +1139,7 @@ if ( ! class_exists( 'um\core\Builtin' ) ) {
 					'required'      => 0,
 					'public'        => 1,
 					'editable'      => 1,
-					'default'       => '0',
+					'default'       => UM()->roles()->um_user_can( 'profile_noindex' ) ? '1' : '0',
 					'options'       => array(
 						'0'     => __( 'No', 'ultimate-member' ),
 						'1'     => __( 'Yes', 'ultimate-member' ),

--- a/includes/core/class-user.php
+++ b/includes/core/class-user.php
@@ -1687,6 +1687,52 @@ if ( ! class_exists( 'um\core\User' ) ) {
 
 
 		/**
+		 * This method checks if the profile indexing is disabled
+		 *
+		 * @since 2.1.14 [2020-12-22]
+		 * @usage <?php UM()->user()->is_profile_noindex(); ?>
+		 *
+		 * @return boolean  Is the profile indexing disabled?
+		 */
+		function is_profile_noindex(){
+			$user_id = $this->id;
+
+			$profile_noindex = false;
+			
+			if ( !get_option( 'blog_public' ) ){
+				// Option "Search engine visibility" in [wp-admin > Settings > Reading]
+				$profile_noindex = true;
+
+			} elseif ( $this->is_private_profile( $user_id ) ){
+				// Setting "Profile Privacy" in [Account > Privacy]
+				$profile_noindex = true;
+
+			} elseif ( get_user_meta( $user_id, 'profile_noindex', true ) === '1' ){
+				// Setting "Avoid indexing my profile by search engines in [Account > Privacy]
+				$profile_noindex = true;
+				
+			}
+			
+			if( ! $profile_noindex ){
+				$role = UM()->roles()->get_priority_user_role( $user_id );
+				$permissions = UM()->roles()->role_data( $role );
+				
+				if ( isset( $permissions['profile_noindex'] ) && $permissions['profile_noindex'] === '1' ) {
+					// Setting "Avoid indexing profile by search engines" in [wp-admin > Ultimate Member > User Roles > Edit Role]
+					$profile_noindex = true;
+
+				} elseif ( empty( $permissions['profile_noindex'] ) && UM()->options()->get( 'profile_noindex' ) === '1' ){
+					// Setting "Avoid indexing profile by search engines" in [wp-admin > Ultimate Member > Settings > General > Users]
+					$profile_noindex = true;
+
+				}
+			}
+
+			return apply_filters( 'um_user_is_profile_noindex', $profile_noindex, $this );
+		}
+
+
+		/**
 		 * This method checks if give user profile is private.
 		 *
 		 * @usage <?php UM()->user()->is_private_profile( $user_id ); ?>

--- a/includes/core/um-actions-profile.php
+++ b/includes/core/um-actions-profile.php
@@ -680,32 +680,22 @@ function um_profile_dynamic_meta_desc() {
 
 		$user_id = um_get_requested_user();
 
-		$privacy = get_user_meta( $user_id, 'profile_privacy', true );
-		if ( $privacy == __( 'Only me', 'ultimate-member' ) || $privacy == 'Only me' ) {
-			echo '<meta name="robots" content="noindex, nofollow" />';
-			return;
-		}
-		
-		/**
-		 * @see the user role setting "Avoid indexing profile by search engines"
-		 */
-		$role = UM()->roles()->get_priority_user_role( $user_id );
-		$permissions = UM()->roles()->role_data( $role );
-		if ( ! empty( $permissions['profile_noindex'] ) ) {
-			echo '<meta name="robots" content="noindex, nofollow" />';
-			return;
+		if( $user_id !== um_user('ID') ){
+			um_fetch_user( $user_id );
 		}
 
 		/**
-		 * @see the account setting "Avoid indexing my profile by search engines"
+		 * Settings by the priority:
+		 *  "Search engine visibility" in [wp-admin > Settings > Reading]
+		 *  "Profile Privacy" in [Account > Privacy]
+		 *  "Avoid indexing my profile by search engines in [Account > Privacy]
+		 *  "Avoid indexing profile by search engines" in [wp-admin > Ultimate Member > User Roles > Edit Role]
+		 *  "Avoid indexing profile by search engines" in [wp-admin > Ultimate Member > Settings > General > Users]
 		 */
-		$noindex = get_user_meta( $user_id, 'profile_noindex', true );
-		if ( ! empty( $noindex ) ) {
+		if ( UM()->user()->is_profile_noindex() ) {
 			echo '<meta name="robots" content="noindex, nofollow" />';
 			return;
 		}
-
-		um_fetch_user( $user_id );
 
 		$locale = get_user_locale( $user_id );
 		$site_name = get_bloginfo( 'name' );

--- a/includes/core/um-actions-profile.php
+++ b/includes/core/um-actions-profile.php
@@ -682,15 +682,27 @@ function um_profile_dynamic_meta_desc() {
 
 		$privacy = get_user_meta( $user_id, 'profile_privacy', true );
 		if ( $privacy == __( 'Only me', 'ultimate-member' ) || $privacy == 'Only me' ) {
+			echo '<meta name="robots" content="noindex, nofollow" />';
+			return;
+		}
+		
+		/**
+		 * @see the user role setting "Avoid indexing profile by search engines"
+		 */
+		$role = UM()->roles()->get_priority_user_role( $user_id );
+		$permissions = UM()->roles()->role_data( $role );
+		if ( ! empty( $permissions['profile_noindex'] ) ) {
+			echo '<meta name="robots" content="noindex, nofollow" />';
 			return;
 		}
 
+		/**
+		 * @see the account setting "Avoid indexing my profile by search engines"
+		 */
 		$noindex = get_user_meta( $user_id, 'profile_noindex', true );
-		if ( ! empty( $noindex ) ) { ?>
-
-			<meta name="robots" content="noindex, nofollow" />
-
-			<?php return;
+		if ( ! empty( $noindex ) ) {
+			echo '<meta name="robots" content="noindex, nofollow" />';
+			return;
 		}
 
 		um_fetch_user( $user_id );

--- a/includes/core/um-filters-account.php
+++ b/includes/core/um-filters-account.php
@@ -44,3 +44,18 @@ function um_account_sanitize_data( $data ) {
 	return $data;
 }
 add_filter( 'um_account_pre_updating_profile_array', 'um_account_sanitize_data', 10, 1 );
+
+
+/**
+ * Fix for the account field "Avoid indexing my profile by search engines"
+ * @since  2.1.14 [2020-12-15]
+ * @param  bool   $value
+ * @return int
+ */
+function um_account_profile_noindex_value( $value ) {
+	if ( ! is_numeric( $value ) ) {
+		$value = (int) get_user_meta( um_profile_id(), 'profile_noindex', true );
+	}
+	return $value;
+}
+add_filter( 'um_profile_profile_noindex_empty__filter', 'um_account_profile_noindex_value' );


### PR DESCRIPTION
New user role setting "Avoid indexing profile by search engines" is added. This setting sets the default value for the account setting "Avoid indexing my profile by search engines".

![UM User Roles, Edit Role + Avoid indexing profile by search engines](https://user-images.githubusercontent.com/28895658/102237224-17b02580-3efd-11eb-84b7-e986e52051b7.png)

**Proposition 1**
I think it would be better to remove the account setting "Avoid indexing my profile by search engines". Users can avoid indexing by making their profiles private. Users may be confused by seeing a lot of similar settings.

![UM Account page, Profile Privacy + Avoid indexing my profile by search engines](https://user-images.githubusercontent.com/28895658/102238595-98235600-3efe-11eb-8da0-1379fb2829f8.png)

**Proposition 2**
I think it would be better to change the logic to opposite - disable indexing by default and change the user role setting "Avoid indexing profile by search engines" to the "Allow indexing profile by search engines".