### PR TITLE
Show button to generate default pages if lost.

### DIFF
--- a/includes/admin/core/class-admin-settings.php
+++ b/includes/admin/core/class-admin-settings.php
@@ -235,6 +235,10 @@ if ( ! class_exists( 'um\admin\core\Admin_Settings' ) ) {
 				)
 			);
 
+			$general_pages_fields_options = array_replace( [
+				'' => __( 'Select...', 'ultimate-member' )
+			], UM()->query()->wp_pages() );
+
 			$core_pages = UM()->config()->core_pages;
 
 			foreach ( $core_pages as $page_s => $page ) {
@@ -257,7 +261,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Settings' ) ) {
 						'id'            => $page_id,
 						'type'          => 'select',
 						'label'         => sprintf( __( '%s page', 'ultimate-member' ), $page_title ),
-						'options'       => UM()->query()->wp_pages(),
+						'options'       => $general_pages_fields_options,
 						'placeholder'   => __( 'Choose a page...', 'ultimate-member' ),
 						'compiler'      => true,
 						'size'          => 'small'

--- a/includes/core/class-setup.php
+++ b/includes/core/class-setup.php
@@ -255,6 +255,9 @@ KEY meta_value_indx (um_value(191))
 			}
 
 			update_option( 'um_options', $options );
+
+			// show all notices after the plugin activation
+			update_option( 'um_hidden_admin_notices', array() );
 		}
 
 


### PR DESCRIPTION
Changes:
1) Show a notice and a button to generate default pages if one of the pages is lost.
2) New notice _'Ultimate Member Setup Error: Account page and User page should be separate pages.'_
3) Display the empty option _'Select...'_ for pages that were not selected.
4) Clear a list of hidden admin notices on the core plugin re-activation.