### PR TITLE
Set the locale to the locale of the email recepient

### DIFF
--- a/includes/core/class-mail.php
+++ b/includes/core/class-mail.php
@@ -405,6 +405,10 @@ if ( ! class_exists( 'um\core\Mail' ) ) {
 				return;
 			}
 
+			$user = get_user_by( 'email', $email );
+			$user_locale = get_user_meta( $user->ID, 'user_locale', true );
+			do_action( 'wpml_switch_language', $user_locale );
+
 			$this->attachments = array();
 			$this->headers = 'From: '. stripslashes( UM()->options()->get('mail_from') ) .' <'. UM()->options()->get('mail_from_addr') .'>' . "\r\n";
 


### PR DESCRIPTION
Currently when using the Ultimate Member with together with WPML plugin there is an issue with emails that are sent to the user of the website. Let me describe a case:

A new user registers from a page in German language and the locale of this user is set to German. When admin approves his account via Ultimate Member - if the admin's locale is English, then the notification about the account approval is sent in English language, which is not acceptable, as the user is obviously German speaking. 

I have implemented a following solution, which seems quite ugly, but it works for me. Please let me know if we can somehow add this kind of code into the Ultimate Member to avoid such an issue.