### PR TITLE
Allow non-admin users to approve another users in the backend

### DIFF
--- a/includes/core/um-actions-core.php
+++ b/includes/core/um-actions-core.php
@@ -37,6 +37,9 @@ function um_action_request_process() {
 		$uid = absint( $_REQUEST['uid'] );
 	}
 
+	$role = get_role( UM()->roles()->get_priority_user_role( get_current_user_id() ) );
+	$can_edit_users = current_user_can( 'edit_users' ) && $role->has_cap( 'edit_users' );
+
 	switch ( $_REQUEST['um_action'] ) {
 		default:
 			/**
@@ -85,7 +88,7 @@ function um_action_request_process() {
 			break;
 
 		case 'um_reject_membership':
-			if ( ! current_user_can( 'manage_options' ) ) {
+			if ( ! $can_edit_users ) {
 				wp_die( __( 'You do not have permission to make this action.', 'ultimate-member' ) );
 			}
 
@@ -96,7 +99,7 @@ function um_action_request_process() {
 
 		case 'um_approve_membership':
 		case 'um_reenable':
-			if ( ! current_user_can( 'manage_options' ) ) {
+			if ( ! $can_edit_users ) {
 				wp_die( __( 'You do not have permission to make this action.', 'ultimate-member' ) );
 			}
 
@@ -109,7 +112,7 @@ function um_action_request_process() {
 			break;
 
 		case 'um_put_as_pending':
-			if ( ! current_user_can( 'manage_options' ) ) {
+			if ( ! $can_edit_users ) {
 				wp_die( __( 'You do not have permission to make this action.', 'ultimate-member' ) );
 			}
 
@@ -119,7 +122,7 @@ function um_action_request_process() {
 			break;
 
 		case 'um_resend_activation':
-			if ( ! current_user_can( 'manage_options' ) ) {
+			if ( ! $can_edit_users ) {
 				wp_die( __( 'You do not have permission to make this action.', 'ultimate-member' ) );
 			}
 
@@ -132,7 +135,7 @@ function um_action_request_process() {
 			break;
 
 		case 'um_deactivate':
-			if ( ! current_user_can( 'manage_options' ) ) {
+			if ( ! $can_edit_users ) {
 				wp_die( __( 'You do not have permission to make this action.', 'ultimate-member' ) );
 			}
 

--- a/includes/core/um-filters-user.php
+++ b/includes/core/um-filters-user.php
@@ -13,7 +13,7 @@ function um_admin_user_actions_hook( $actions, $user_id ) {
 	um_fetch_user( $user_id );
 
 	//if ( UM()->roles()->um_current_user_can( 'edit', $user_id ) ) {
-	if ( current_user_can( 'manage_options' ) ) {
+	if ( current_user_can( 'edit_users' ) ) {
 
 		if ( um_user( 'account_status' ) == 'awaiting_admin_review' ) {
 			$actions['um_approve_membership'] = array( 'label' => __( 'Approve Membership', 'ultimate-member' ) );


### PR DESCRIPTION
This change allows users who have the capability '**edit_users**' to approve a user or change a user status.

**Note:** The 'list_users' capability allows users to view a list of users in the admin area. We have to use a stricter capability 'edit_users' for actions that change user's status.