### PR TITLE
Missing Password Changed confirmation email notification after reseting password via password reset page.

### DIFF
--- a/includes/core/class-password.php
+++ b/includes/core/class-password.php
@@ -618,8 +618,15 @@ if ( ! class_exists( 'um\core\Password' ) ) {
 
 				if ( ( ! $errors->get_error_code() ) ) {
 					reset_password( $user, $args['user_password'] );
-					delete_user_meta( $args['user_id'], 'password_rst_attempts' );
+
+					// send the Password Changed Email
+					UM()->user()->password_changed();
+
+					// clear temporary data
+					update_user_meta( $user->ID, 'password_rst_attempts', 0 );
 					$this->setcookie( $rp_cookie, false );
+
+					// logout
 					if ( is_user_logged_in() ) {
 						wp_logout();
 					}


### PR DESCRIPTION
Sends the "Password Changed Email" when the password is changed via password reset page.