### PR TITLE
jQuery 3 compatibility (for WordPress 5.7 and higher)

### DIFF
--- a/assets/js/um-conditional.js
+++ b/assets/js/um-conditional.js
@@ -244,7 +244,7 @@ function um_apply_conditions( $dom, is_single_update ) {
 		}
 
 		if ( condition.operator === 'empty' ) {
-			var field_value = jQuery.isArray( live_field_value ) ? live_field_value.join('') : live_field_value;
+			var field_value = Array.isArray( live_field_value ) ? live_field_value.join('') : live_field_value;
 			if ( ! field_value || field_value === '' ) {
 				$owners[ condition.owner ][ index ] = true;
 			} else {
@@ -253,7 +253,7 @@ function um_apply_conditions( $dom, is_single_update ) {
 		}
 
 		if ( condition.operator === 'not empty' ) {
-			var field_value = jQuery.isArray( live_field_value ) ? live_field_value.join('') : live_field_value;
+			var field_value = Array.isArray( live_field_value ) ? live_field_value.join('') : live_field_value;
 			if ( field_value && field_value !== '' ) {
 				$owners[ condition.owner ][ index ] = true;
 			} else {
@@ -262,7 +262,7 @@ function um_apply_conditions( $dom, is_single_update ) {
 		}
 
 		if ( condition.operator === 'equals to' ) {
-			var field_value = ( jQuery.isArray( live_field_value ) && live_field_value.length === 1 ) ? live_field_value[0] : live_field_value;
+			var field_value = ( Array.isArray( live_field_value ) && live_field_value.length === 1 ) ? live_field_value[0] : live_field_value;
 			if ( condition.value === field_value && um_in_array( field_value, $owners_values[ condition.owner ] ) ) {
 				$owners[ condition.owner ][ index ] = true;
 			} else {
@@ -271,7 +271,7 @@ function um_apply_conditions( $dom, is_single_update ) {
 		}
 
 		if ( condition.operator === 'not equals' ) {
-			var field_value = ( jQuery.isArray( live_field_value ) && live_field_value.length === 1 ) ? live_field_value[0] : live_field_value;
+			var field_value = ( Array.isArray( live_field_value ) && live_field_value.length === 1 ) ? live_field_value[0] : live_field_value;
 			if ( jQuery.isNumeric(condition.value) && parseInt(field_value) !== parseInt( condition.value ) && field_value && ! um_in_array( field_value, $owners_values[ condition.owner ] ) ) {
 				$owners[ condition.owner ][ index ] = true;
 			} else if ( condition.value != field_value && ! um_in_array( field_value, $owners_values[ condition.owner ] ) ) {
@@ -282,7 +282,7 @@ function um_apply_conditions( $dom, is_single_update ) {
 		}
 
 		if ( condition.operator === 'greater than' ) {
-			var field_value = ( jQuery.isArray( live_field_value ) && live_field_value.length === 1 ) ? live_field_value[0] : live_field_value;
+			var field_value = ( Array.isArray( live_field_value ) && live_field_value.length === 1 ) ? live_field_value[0] : live_field_value;
 			if ( jQuery.isNumeric( condition.value ) && parseInt( field_value ) > parseInt( condition.value ) ) {
 				$owners[ condition.owner ][ index ] = true;
 			} else {
@@ -291,7 +291,7 @@ function um_apply_conditions( $dom, is_single_update ) {
 		}
 
 		if ( condition.operator === 'less than' ) {
-			var field_value = ( jQuery.isArray( live_field_value ) && live_field_value.length === 1 ) ? live_field_value[0] : live_field_value;
+			var field_value = ( Array.isArray( live_field_value ) && live_field_value.length === 1 ) ? live_field_value[0] : live_field_value;
 			if ( jQuery.isNumeric( condition.value ) && parseInt( field_value ) < parseInt( condition.value ) ) {
 				$owners[ condition.owner ][ index ] = true;
 			} else {
@@ -424,12 +424,12 @@ function um_field_restore_default_value( $dom ) {
 		case 'checkbox':
 			if ( $dom.find('input[type="checkbox"]:checked').length >= 1 ) {
 
-				$dom.find('input[type="checkbox"]:checked').removeAttr('checked');
+				$dom.find('input[type="checkbox"]:checked').prop('checked', false);
 				$dom.find('span.um-field-checkbox-state i').removeClass('um-icon-android-checkbox-outline');
 				$dom.find('span.um-field-checkbox-state i').addClass('um-icon-android-checkbox-outline-blank');
 				$dom.find('.um-field-checkbox.active').removeClass('active');
 
-				if ( jQuery.isArray( field.value ) ) {
+				if ( Array.isArray( field.value ) ) {
 					jQuery.each( field.value, function ( i, value ) {
 						var cbox_elem = $dom.find('input[type="checkbox"][value="' + value + '"]');
 						cbox_elem.attr('checked', true);
@@ -453,7 +453,7 @@ function um_field_restore_default_value( $dom ) {
 
 				setTimeout( function() {
 
-					$dom.find('input[type="radio"]:checked').removeAttr('checked');
+					$dom.find('input[type="radio"]:checked').prop('checked', false);
 
 					$dom.find('span.um-field-radio-state i').removeClass('um-icon-android-radio-button-on');
 					$dom.find('span.um-field-radio-state i').addClass('um-icon-android-radio-button-off');

--- a/assets/js/um-functions.js
+++ b/assets/js/um-functions.js
@@ -744,16 +744,16 @@ function um_reset_field( dOm ){
 	 .find('input,textarea,select')
 	 .not(':button, :submit, :reset, :hidden')
 	 .val('')
-	 .removeAttr('checked')
-	 .removeAttr('selected');
+	 .prop('checked', false)
+	 .prop('selected', false);
 }
 
 jQuery(function(){
 
 	// Submit search form on keypress 'Enter'
-	jQuery(".um-search form *").keypress(function(e){
+	jQuery(".um-search form *").on( 'keypress', function(e){
 			 if (e.which == 13) {
-			    jQuery('.um-search form').submit();
+			    jQuery('.um-search form').trigger('submit');
 			    return false;
 			  }
 	});

--- a/assets/js/um-jquery-form.js
+++ b/assets/js/um-jquery-form.js
@@ -364,7 +364,7 @@ $.fn.ajaxSubmit = function(options) {
                     el.prop('disabled', false);
                 }
                 else {
-                    el.removeAttr('disabled');
+                    el.prop('disabled', false);
                 }
             }
         }

--- a/assets/js/um-members.js
+++ b/assets/js/um-members.js
@@ -53,7 +53,7 @@ function um_set_url_from_data( directory, key, value ) {
 
 	var new_data = {};
 
-	if ( jQuery.isArray( value ) ) {
+	if ( Array.isArray( value ) ) {
 		jQuery.each( value, function( i ) {
 			value[ i ] = encodeURIComponent( value[ i ] );
 		});
@@ -924,7 +924,7 @@ jQuery(document.body).ready( function() {
 
 
 	//filters controls
-	jQuery('.um-member-directory-filters-a').click( function() {
+	jQuery('.um-member-directory-filters-a').on( 'click', function() {
 		var obj = jQuery(this);
 		var search_bar = obj.parents('.um-directory').find('.um-search');
 

--- a/assets/js/um-profile.js
+++ b/assets/js/um-profile.js
@@ -15,7 +15,7 @@ jQuery(document).ready(function() {
 
 	jQuery( document.body ).on( 'click', '.um-profile-save', function(e){
 		e.preventDefault();
-		jQuery(this).parents('.um').find('form').submit();
+		jQuery(this).parents('.um').find('form').trigger('submit');
 		return false;
 	});
 
@@ -104,7 +104,7 @@ jQuery(document).ready(function() {
 	}*/
 
 	//um_update_bio_countdown();
-	//jQuery( 'textarea[id="um-meta-bio"]' ).change( um_update_bio_countdown ).keyup( um_update_bio_countdown ).trigger('change');
+	//jQuery( 'textarea[id="um-meta-bio"]' ).on('change', um_update_bio_countdown ).keyup( um_update_bio_countdown ).trigger('change');
 
 	// Bio characters limit
 	jQuery( document.body ).on( 'change, keyup', 'textarea[id="um-meta-bio"]', function() {
@@ -122,7 +122,7 @@ jQuery(document).ready(function() {
 	jQuery( 'textarea[id="um-meta-bio"]' ).trigger('change');
 
 
-	jQuery( '.um-profile-edit a.um_delete-item' ).click( function(e) {
+	jQuery( '.um-profile-edit a.um_delete-item' ).on( 'click', function(e) {
 		e.preventDefault();
 
 		if ( ! confirm( wp.i18n.__( 'Are you sure that you want to delete this user?', 'ultimate-member' ) ) ) {
@@ -135,7 +135,7 @@ jQuery(document).ready(function() {
 	 * @see https://www.html5rocks.com/en/mobile/touchandmouse/
 	 */
 	jQuery( '.um-profile-nav a' ).on( 'touchend', function(e) {
-		e.currentTarget.click();
+		jQuery( e.currentTarget).trigger( "click" );
 	});
 
 });

--- a/assets/js/um-scripts.js
+++ b/assets/js/um-scripts.js
@@ -469,11 +469,11 @@ jQuery(document).ready(function() {
 		}
 	});
 
-	jQuery('.um-form input[class="um-button"][type="submit"]').removeAttr('disabled');
+	jQuery('.um-form input[class="um-button"][type="submit"]').prop('disabled', false);
 
 	jQuery(document).one('click', '.um:not(.um-account) .um-form input[class="um-button"][type="submit"]:not(.um-has-recaptcha)', function() {
 		jQuery(this).attr('disabled','disabled');
-		jQuery(this).parents('form').submit();
+		jQuery(this).parents('form').trigger('submit');
 	});
 
 
@@ -577,7 +577,7 @@ jQuery(document).ready(function() {
 		me.find('option[value!=""]').remove();
 
 		if ( ! me.hasClass('um-child-option-disabled') ) {
-			me.removeAttr('disabled');
+			me.prop('disabled', false);
 		}
 
 		var arr_items = [],

--- a/includes/admin/assets/js/um-admin-dragdrop.js
+++ b/includes/admin/assets/js/um-admin-dragdrop.js
@@ -12,7 +12,7 @@ function UM_Drag_and_Drop() {
 				
 				jQuery('.um-admin-drag-col,.um-admin-drag-group').sortable('cancel');
 				
-				jQuery('#publish').removeAttr('disabled');
+				jQuery('#publish').prop('disabled', false);
 				
 			} else {
 				
@@ -246,7 +246,7 @@ function UM_Rows_Refresh(){
 		type: 'POST',
 		data: jQuery( '.um_update_order' ).serialize(),
 		success: function(){
-			jQuery('#publish').removeAttr('disabled');
+			jQuery('#publish').prop('disabled', false);
 		}
 	});
 	

--- a/includes/admin/assets/js/um-admin-field.js
+++ b/includes/admin/assets/js/um-admin-field.js
@@ -45,7 +45,7 @@ jQuery(document).ready(function() {
                 jQuery( this ).find('[id^="_conditional_field"]').val() === '' ||
                 jQuery( this ).find('[id^="_conditional_operator"]').val() ==='' )
             {
-                jQuery(conditions[i]).find('.um-admin-remove-condition').click();
+                jQuery(conditions[i]).find('.um-admin-remove-condition').trigger('click');
             }
         } );
         conditions = jQuery('.um-admin-cur-condition');
@@ -85,7 +85,7 @@ jQuery(document).ready(function() {
 					jQuery.each(data.error, function(i, v){
 						c++;
 						if ( c == 1 ) {
-						form.find('#'+i).addClass('um-admin-error').focus();
+						form.find('#'+i).addClass('um-admin-error').trigger('focus');
 						form.find('.um-admin-error-block').show().html(v);
 						}
 					});

--- a/includes/admin/assets/js/um-admin-form.js
+++ b/includes/admin/assets/js/um-admin-form.js
@@ -26,7 +26,7 @@ jQuery(document).ready(function() {
 
 
 	/* Creating new form button */
-	jQuery('.um-admin-boxed-links:not(.is-core-form) a').click( function() {
+	jQuery('.um-admin-boxed-links:not(.is-core-form) a').on( 'click', function() {
 		um_form_select_tab( jQuery(this), true );
 	});
 });

--- a/includes/admin/assets/js/um-admin-forms.js
+++ b/includes/admin/assets/js/um-admin-forms.js
@@ -177,7 +177,7 @@ jQuery(document).ready( function() {
 		}
 	});
 
-	jQuery( '.um-forms-line[data-field_type="md_sorting_fields"] .um-multi-selects-add-option' ).click( function() {
+	jQuery( '.um-forms-line[data-field_type="md_sorting_fields"] .um-multi-selects-add-option' ).on('click', function() {
 		var list = jQuery(this).siblings('ul.um-multi-selects-list');
 
 		var sortable = list.hasClass( 'um-sortable-multi-selects' );
@@ -238,7 +238,7 @@ jQuery(document).ready( function() {
 		jQuery( this ).parents( 'li.um-md-default-filters-option-line' ).remove();
 	});
 
-	jQuery( '.um-multi-selects-add-option' ).click( function() {
+	jQuery( '.um-multi-selects-add-option' ).on('click', function() {
 		if ( jQuery(this).parents( '.um-forms-line[data-field_type="md_sorting_fields"]' ).length ) {
 			return;
 		}
@@ -518,7 +518,7 @@ jQuery(document).ready( function() {
 	}
 
 
-	jQuery( '.um-md-default-filters-add-option' ).click( function() {
+	jQuery( '.um-md-default-filters-add-option' ).on('click', function() {
 		if ( um_member_dir_filters_busy ) {
 			return;
 		}
@@ -554,7 +554,7 @@ jQuery(document).ready( function() {
 	});
 
 
-	jQuery( '.um-multi-text-add-option' ).click( function() {
+	jQuery( '.um-multi-text-add-option' ).on('click', function() {
 		var list = jQuery(this).siblings( 'ul.um-multi-text-list' );
 
 		var field_id = list.data( 'field_id' );
@@ -602,7 +602,7 @@ jQuery(document).ready( function() {
 	if ( typeof wp !== 'undefined' && wp.media && wp.media.editor ) {
 		var frame;
 
-		jQuery( '.um-set-image' ).click( function(e) {
+		jQuery( '.um-set-image' ).on('click', function(e) {
 			var button = jQuery(this);
 
 			e.preventDefault();
@@ -648,11 +648,11 @@ jQuery(document).ready( function() {
 			frame.open();
 		});
 
-		jQuery('.icon_preview').click( function(e) {
+		jQuery('.icon_preview').on('click', function(e) {
 			jQuery(this).siblings('.um-set-image').trigger('click');
 		});
 
-		jQuery('.um-clear-image').click( function(e) {
+		jQuery('.um-clear-image').on('click', function(e) {
 			var clear_button = jQuery(this);
 			var default_image_url = clear_button.siblings('.um-forms-field').data('default');
 			clear_button.siblings('.um-set-image').show();

--- a/includes/admin/assets/js/um-admin-role-wrapper.js
+++ b/includes/admin/assets/js/um-admin-role-wrapper.js
@@ -1,6 +1,6 @@
 jQuery( document ).ready( function() {
 
-	jQuery( '#role' ).change( function() {
+	jQuery( '#role' ).on('change', function() {
 
 		if ( typeof um_roles == 'object' ) {
 			um_roles = Object.keys( um_roles ).map(function( key ) { return um_roles[ key ]; });
@@ -20,7 +20,7 @@ jQuery( document ).ready( function() {
 		}
 	}).trigger('change');
 
-	jQuery( '#adduser-role' ).change( function() {
+	jQuery( '#adduser-role' ).on('change', function() {
 		if ( typeof um_roles == 'object' ) {
 			um_roles = Object.keys( um_roles ).map(function( key ) { return um_roles[ key ]; });
 		}

--- a/includes/admin/assets/js/um-admin-scripts.js
+++ b/includes/admin/assets/js/um-admin-scripts.js
@@ -128,7 +128,7 @@ jQuery(document).ready(function() {
 	/**
 		Ajax link
 	**/
-	jQuery('.um-admin-ajaxlink').click(function(e){
+	jQuery('.um-admin-ajaxlink').on('click', function(e){
 		e.preventDefault();
 		return false;
 	});
@@ -229,7 +229,7 @@ jQuery(document).ready(function() {
 		Conditional fields for
 		Radio Group
 	**/
-	jQuery('.um-conditional-radio-group input[type=radio]').click(function(){
+	jQuery('.um-conditional-radio-group input[type=radio]').on('click', function(){
 		var holder = jQuery('.um-conditional-radio-group');
 		
 		var val = jQuery(this).val();

--- a/includes/admin/assets/js/um-admin-settings.js
+++ b/includes/admin/assets/js/um-admin-settings.js
@@ -4,7 +4,7 @@ jQuery( document ).ready( function() {
 	 */
 	jQuery( document.body ).on( 'click', '.um_license_deactivate', function() {
 		jQuery(this).siblings('.um-option-field').val('');
-		jQuery(this).parents('form.um-settings-form').submit();
+		jQuery(this).parents('form.um-settings-form').trigger('submit');
 	});
 
 
@@ -14,11 +14,11 @@ jQuery( document ).ready( function() {
 	if ( jQuery( '#licenses_settings' ).length === 0 ) {
 		var changed = false;
 
-		jQuery( 'input, textarea, select' ).change( function() {
+		jQuery( 'input, textarea, select' ).on('change', function() {
 			changed = true;
 		});
 
-		jQuery( '#um-settings-wrap .um-nav-tab-wrapper a, #um-settings-wrap .subsubsub a' ).click( function() {
+		jQuery( '#um-settings-wrap .um-nav-tab-wrapper a, #um-settings-wrap .subsubsub a' ).on( 'click', function() {
 			if ( changed ) {
 				window.onbeforeunload = function() {
 					return wp.i18n.__( 'Are sure, maybe some settings not saved', 'ultimate-member' );
@@ -28,7 +28,7 @@ jQuery( document ).ready( function() {
 			}
 		});
 
-		jQuery( '.submit input' ).click( function() {
+		jQuery( '.submit input' ).on( 'click', function() {
 			window.onbeforeunload = '';
 		});
 	}

--- a/includes/core/class-user.php
+++ b/includes/core/class-user.php
@@ -1721,7 +1721,7 @@ if ( ! class_exists( 'um\core\User' ) ) {
 					// Setting "Avoid indexing profile by search engines" in [wp-admin > Ultimate Member > User Roles > Edit Role]
 					$profile_noindex = true;
 
-				} elseif ( $permissions['profile_noindex'] === '' && UM()->options()->get( 'profile_noindex' ) === '1' ) {
+				} elseif ( ( ! isset( $permissions['profile_noindex'] ) || $permissions['profile_noindex'] === '' ) && UM()->options()->get( 'profile_noindex' ) === '1' ) {
 					// Setting "Avoid indexing profile by search engines" in [wp-admin > Ultimate Member > Settings > General > Users]
 					$profile_noindex = true;
 


### PR DESCRIPTION
jQuery.fn.change() event shorthand is deprecated
jQuery.fn.click() event shorthand is deprecated
jQuery.fn.focus() event shorthand is deprecated
jQuery.fn.keypress() event shorthand is deprecated
jQuery.fn.removeAttr no longer sets boolean properties: disabled
jQuery.fn.submit() event shorthand is deprecated
jQuery.isArray is deprecated; use Array.isArray