### PR TITLE
UM access Controls

### DIFF
--- a/includes/admin/assets/css/um-admin-global.css
+++ b/includes/admin/assets/css/um-admin-global.css
@@ -204,7 +204,8 @@ a.um-delete{ color: #a00; }
 }
 
 .um_hidden_notice,
-.um_block_settings_hide {
+.um_block_settings_hide,
+.components-select-control.um_block_settings_hide{
 	display: none;
 }
 

--- a/includes/admin/assets/css/um-admin-global.css
+++ b/includes/admin/assets/css/um-admin-global.css
@@ -203,9 +203,18 @@ a.um-delete{ color: #a00; }
 	margin-bottom: 2px !important;
 }
 
+/*
+	- Restrict access
+*/
+
 .um_hidden_notice,
-.um_block_settings_hide,
-.components-select-control.um_block_settings_hide{
+.um_block_settings .um_block_settings_hide{
+	display: none;
+}
+.um_block_settings .components-select-control .components-select-control__input[multiple]{
+	height: auto;
+}
+.um_block_settings .components-select-control .components-select-control__input[multiple] + .components-input-control__suffix{
 	display: none;
 }
 

--- a/includes/admin/assets/js/um-admin-blocks-shortcode.js
+++ b/includes/admin/assets/js/um-admin-blocks-shortcode.js
@@ -365,7 +365,7 @@ wp.blocks.registerBlockType( 'um-block/um-account', {
 				wp.i18n.__( 'Account', 'ultimate-member' )
 			),
 			wp.element.createElement(
-				wp.editor.InspectorControls,
+				wp.blockEditor.InspectorControls,
 				{},
 				wp.element.createElement(
 					wp.components.PanelBody,

--- a/includes/admin/assets/js/um-admin-blocks.js
+++ b/includes/admin/assets/js/um-admin-blocks.js
@@ -65,7 +65,8 @@ var um_block_restriction = wp.compose.createHigherOrderComponent( function( Bloc
 				wp.element.createElement(
 					wp.components.PanelBody,
 					{
-						title: wp.i18n.__( 'UM access Controls', 'ultimate-member' )
+						title: wp.i18n.__( 'UM access Controls', 'ultimate-member' ),
+						className: 'um_block_settings'
 					},
 					wp.element.createElement(
 						wp.components.ToggleControl,

--- a/includes/admin/assets/js/um-admin-blocks.js
+++ b/includes/admin/assets/js/um-admin-blocks.js
@@ -60,7 +60,7 @@ var um_block_restriction = wp.compose.createHigherOrderComponent( function( Bloc
 			{},
 			wp.element.createElement( BlockEdit, props ),
 			wp.element.createElement(
-				wp.editor.InspectorControls,
+				wp.blockEditor.InspectorControls,
 				{},
 				wp.element.createElement(
 					wp.components.PanelBody,


### PR DESCRIPTION
Fixed: Conditional settings "Who can access this content?", "What roles can access this content?", "Restriction Action" are hidden if the parent setting "Restrict access?" is turned off.

Image 1 - The setting "Restrict access?" is turned off.
![off](https://user-images.githubusercontent.com/78854651/112866618-a880ca80-90c2-11eb-8194-4d8525a16773.png)

Image 2 - The setting "Restrict access?" is turned on.
![on](https://user-images.githubusercontent.com/78854651/112866605-a585da00-90c2-11eb-9c7f-e8cb365480f4.png)