### PR TITLE
Allow soundcloud URLs to be passed in addition to track ids

### DIFF
--- a/includes/core/um-filters-fields.php
+++ b/includes/core/um-filters-fields.php
@@ -30,10 +30,20 @@ add_filter( 'um_edit_label_all_fields', 'um_edit_label_all_fields', 10, 2 );
  */
 function um_profile_field_filter_hook__soundcloud_track( $value, $data ) {
 
-	if ( ! is_numeric( $value ) ) {
-		return __( 'Invalid soundcloud track ID', 'ultimate-member' );
+	if ( !is_numeric( $value ) ) {
+		# if we're passed a track url:
+		if ( preg_match( '/https:\/\/soundcloud.com\/.*/', $value ) ) {
+			$value = '<div class="um-soundcloud">
+					<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=' . urlencode($value) . '&amp;color=ff6600&amp;auto_play=false&amp;show_artwork=true"></iframe>
+					</div>';
+			return $value;
+		} else {
+			# neither a track id nor url:
+			return __( 'Invalid soundcloud track ID', 'ultimate-member' );
+		}
 	}
-
+	
+	# if we're passed a track id:
 	$value = '<div class="um-soundcloud">
 					<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/' . $value . '&amp;color=ff6600&amp;auto_play=false&amp;show_artwork=true"></iframe>
 					</div>';


### PR DESCRIPTION
Soundcloud allows for a track url to be used in the player instead of the track id. This patch allows either the track id or the track url to be passed to render the iframe for soundcloud.

Recreated for latest version of ultimatemember (originally submitted Dec 13, 2019)