### PR TITLE
User defined label text for the “Confirm password” field

### DIFF
--- a/includes/admin/core/class-admin-metabox.php
+++ b/includes/admin/core/class-admin-metabox.php
@@ -1732,7 +1732,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 					?>
 
 					<p><label for="_force_confirm_pass"><?php _e( 'Automatically add a confirm password field?', 'ultimate-member' ) ?> <?php UM()->tooltip( __( 'Turn on to add a confirm password field. If turned on the confirm password field will only show on register forms and not on login forms.', 'ultimate-member' ) ); ?></label>
-						<input type="checkbox" name="_force_confirm_pass" id="_force_confirm_pass" value="1" <?php checked( isset( $this->edit_mode_value ) ? $this->edit_mode_value : 0 ) ?> />
+						<input type="checkbox" name="_force_confirm_pass" id="_force_confirm_pass" value="1" <?php checked( isset( $this->edit_mode_value ) ? $this->edit_mode_value : 0 ) ?> class="um-adm-conditional" data-cond1="1" data-cond1-show="_label_confirm_pass" data-cond1-hide="xxx" />
 					</p>
 
 					<?php
@@ -2261,6 +2261,16 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 
 					<p><label for="_label"><?php _e( 'Label', 'ultimate-member' ) ?> <?php UM()->tooltip( __( 'The field label is the text that appears above the field on your front-end form. Leave blank to not show a label above field.', 'ultimate-member' ) ); ?></label>
 						<input type="text" name="_label" id="_label" value="<?php echo htmlspecialchars( $this->edit_mode_value, ENT_QUOTES ); ?>" />
+					</p>
+
+					<?php
+					break;
+
+				case '_label_confirm_pass':
+					?>
+
+					<p><label for="_label_confirm_pass"><?php _e( 'Confirm password field label', 'ultimate-member' ) ?> <?php UM()->tooltip( __( 'This label is the text that appears above the confirm password field. Leave blank to show default label.', 'ultimate-member' ) ); ?></label>
+						<input type="text" name="_label_confirm_pass" id="_label_confirm_pass" value="<?php echo htmlspecialchars( $this->edit_mode_value, ENT_QUOTES ); ?>" />
 					</p>
 
 					<?php

--- a/includes/core/class-builtin.php
+++ b/includes/core/class-builtin.php
@@ -352,7 +352,7 @@ if ( ! class_exists( 'um\core\Builtin' ) ) {
 				'password' => array(
 					'name' => 'Password',
 					'col1' => array('_title','_metakey','_help','_min_chars','_max_chars','_visibility'),
-					'col2' => array('_label','_placeholder','_public','_roles','_force_good_pass','_force_confirm_pass'),
+					'col2' => array('_label','_placeholder','_public','_roles','_force_good_pass','_force_confirm_pass','_label_confirm_pass'),
 					'col3' => array('_required','_editable','_icon'),
 					'validate' => array(
 						'_title' => array(
@@ -714,6 +714,7 @@ if ( ! class_exists( 'um\core\Builtin' ) ) {
 					'max_chars' => 30,
 					'force_good_pass' => 1,
 					'force_confirm_pass' => 1,
+					'label_confirm_pass' => __('Confirm Password','ultimate-member')
 				),
 
 				'first_name' => array(

--- a/includes/core/class-fields.php
+++ b/includes/core/class-fields.php
@@ -2388,10 +2388,11 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 							$key = 'confirm_' . $original_key;
 							$output .= '<div ' . $this->get_atts( $key, $classes, $conditional, $data ) . '>';
 
-							if ( isset( $data['label'] ) ) {
-
+							if ( ! empty( $data['label_confirm_pass'] ) ) {
+								$data['label'] = __( $data['label_confirm_pass'], 'ultimate-member' );
+								$output .= $this->field_label( $data['label'], $key, $data );
+							} elseif ( isset( $data['label'] ) ) {
 								$data['label'] = __( $data['label'], 'ultimate-member' );
-
 								$output .= $this->field_label( sprintf( __( 'Confirm %s', 'ultimate-member' ), $data['label'] ), $key, $data );
 							}
 


### PR DESCRIPTION
Added: The field setting "Confirm password field label".

Image - The confirm password field label in the registration form.
![The field setting Confirm password field label](https://user-images.githubusercontent.com/78854651/121029419-3e1a9380-c7b1-11eb-8433-ca92fad22454.png)