### PR TITLE
Fix PHP notice that appears if parameter $id in the method UM()->acce…

### DIFF
--- a/includes/core/class-access.php
+++ b/includes/core/class-access.php
@@ -847,13 +847,15 @@ if ( ! class_exists( 'um\core\Access' ) ) {
 
 
 		/**
-		 * @param $title
-		 * @param $id
+		 * Replace titles of restricted posts
+		 *
+		 * @param string $title
+		 * @param int    $id
 		 *
 		 * @return string
 		 */
 		function filter_restricted_post_title( $title, $id ) {
-			if ( $this->is_restricted( $id ) ) {
+			if ( is_numeric( $id ) && $this->is_restricted( $id ) ) {
 				$restricted_global_title = UM()->options()->get( 'restricted_access_post_title' );
 				$title = stripslashes( $restricted_global_title );
 			}


### PR DESCRIPTION
…ss()->filter_restricted_post_title( $title, $id ) is empty.