### PR TITLE
Social links on update profile

### DIFF
--- a/includes/core/class-form.php
+++ b/includes/core/class-form.php
@@ -586,7 +586,31 @@ if ( ! class_exists( 'um\core\Form' ) ) {
 											}
 											break;
 										case 'url':
-											$form[ $k ] = esc_url_raw( $form[ $k ] );
+                      $f = UM()->builtin()->get_a_field( $k );
+                      if( isset( $f['match'] ) && isset( $f['advanced'] ) && $f['advanced'] === 'social' ){
+                        $v = sanitize_text_field( $form[ $k ] );
+
+                        // Make a proper social link
+                        if ( ! empty( $v ) && ! strstr( $v, $f['match'] ) ) {
+                          $domain = trim( strtr( $f['match'], array(
+                              'https://' => '',
+                              'http://'  => ''
+                          ) ), ' /' );
+
+                          if ( ! strstr( $v, $domain ) ) {
+                            $v = $f['match'] . $v;
+                          } else {
+                            $v = 'https://' . trim( strtr( $v, array(
+                                'https://' => '',
+                                'http://'  => ''
+                            ) ), ' /' );
+                          }
+                        }
+
+                        $form[ $k ] = $v;
+                      } else {
+                        $form[ $k ] = esc_url_raw( $form[ $k ] );
+                      }
 											break;
 										case 'text':
 										case 'select':


### PR DESCRIPTION
Don't use the function esc_url_raw to sanitize social fields. Social strings entered by users may not be URL, it may be their usernames. 
Example: If user enter {username} into the field "Twitter" it should be converted to https://twitter.com/{username}
This fix did it.