### PR TITLE
Add Billing/Shipping State filter to the member directory

### DIFF
--- a/includes/core/class-form.php
+++ b/includes/core/class-form.php
@@ -133,7 +133,9 @@ if ( ! class_exists( 'um\core\Form' ) ) {
 						)
 					);
 
-					if ( ! empty( $values_array ) ) {
+					if ( 0 !== current( array_keys( $arr_options['items'] ) ) ) {
+						$arr_options['items'] = array_intersect_key( array_map( 'trim', $arr_options['items'] ), array_flip( $values_array ) );
+					} elseif ( ! empty( $values_array ) ) {
 						$arr_options['items'] = array_intersect( $arr_options['items'], $values_array );
 					} else {
 						$arr_options['items'] = array();


### PR DESCRIPTION
Support options with keys in member directory.
These changes are needed to add member directory filters `WC Billing state` and `WC Shipping state`

This pull request is related to the pull request in the extension [WooCommerce](https://github.com/ultimatemember/woocommerce).
See https://github.com/ultimatemember/woocommerce/pull/10