### PR TITLE
Add the option to hide the (non-)existence of e-mail addresses by alw…

### DIFF
--- a/includes/admin/core/class-admin-settings.php
+++ b/includes/admin/core/class-admin-settings.php
@@ -1273,6 +1273,12 @@ if ( ! class_exists( 'um\admin\core\Admin_Settings' ) ) {
 								'title'  => __( 'Other', 'ultimate-member' ),
 								'fields' => array(
 									array(
+										'id' => 'enable_hide_valid_email_addresses',
+										'type' => 'checkbox',
+										'label' => __('Hide the existence of an e-mail address when resetting a password'),
+										'tooltip' => __('When enabled, the password reset form will not confirm the existence of an account matching provided details'),
+									),
+									array(
 										'id'    => 'enable_reset_password_limit',
 										'type'  => 'checkbox',
 										'label' => __( 'Enable the Reset Password Limit?', 'ultimate-member' ),

--- a/includes/class-config.php
+++ b/includes/class-config.php
@@ -552,6 +552,7 @@ if ( ! class_exists( 'um\Config' ) ) {
 				'restricted_blocks'                     => 0,
 				'enable_blocks'                         => 0,
 				'restricted_block_message'              => '',
+				'enable_hide_valid_email_addresses'		=> 0,
 				'enable_reset_password_limit'           => 1,
 				'reset_password_limit_number'           => 3,
 				'blocked_emails'                        => '',

--- a/includes/core/class-password.php
+++ b/includes/core/class-password.php
@@ -458,7 +458,11 @@ if ( ! class_exists( 'um\core\Password' ) ) {
 			}
 
 			if ( ( ! is_email( $user ) && ! username_exists( $user ) ) || ( is_email( $user ) && ! email_exists( $user ) ) ) {
-				UM()->form()->add_error( 'username_b', __( 'We can\'t find an account registered with that address or username', 'ultimate-member' ) );
+				if (UM()->options()->get('enable_hide_valid_email_addresses')) {
+					exit( wp_redirect( um_get_core_page('password-reset', 'checkemail' ) ) );
+				} else {
+					UM()->form()->add_error('username_b', __('We can\'t find an account registered with that address or username', 'ultimate-member'));
+				}
 			} else {
 
 				if ( is_email( $user ) ) {

--- a/languages/ultimate-member-en_US.po
+++ b/languages/ultimate-member-en_US.po
@@ -2447,6 +2447,14 @@ msgstr ""
 msgid "Other"
 msgstr ""
 
+#: includes/admin/core/class-admin-settings.php:1278
+msgid "Hide the existence of an e-mail address when resetting a password"
+msgstr ""
+
+#: includes/admin/core/class-admin-settings.php:1279
+msgid "When enabled, the password reset form will not confirm the existence of an account matching provided details"
+msgstr ""
+
 #: includes/admin/core/class-admin-settings.php:824
 msgid "Enable the Reset Password Limit?"
 msgstr ""
@@ -7946,6 +7954,10 @@ msgstr ""
 
 #: templates/password-change.php:47
 msgid "Change my password"
+msgstr ""
+
+#: templates/password-reset.php:14
+msgid "If an account matching the provided details exists, we will send a password reset link. Please check your inbox."
 msgstr ""
 
 #: templates/password-reset.php:10

--- a/languages/ultimate-member.pot
+++ b/languages/ultimate-member.pot
@@ -2357,6 +2357,14 @@ msgstr ""
 msgid "Other"
 msgstr ""
 
+#: includes/admin/core/class-admin-settings.php:1278
+msgid "Hide the existence of an e-mail address when resetting a password"
+msgstr ""
+
+#: includes/admin/core/class-admin-settings.php:1279
+msgid "When enabled, the password reset form will not confirm the existence of an account matching provided details"
+msgstr ""
+
 #: includes/admin/core/class-admin-settings.php:1248
 msgid "Enable the Reset Password Limit?"
 msgstr ""
@@ -7969,6 +7977,11 @@ msgstr ""
 
 #: templates/password-change.php:47
 msgid "Change my password"
+msgstr ""
+
+
+#: templates/password-reset.php:14
+msgid "If an account matching the provided details exists, we will send a password reset link. Please check your inbox."
 msgstr ""
 
 #: templates/password-reset.php:12

--- a/templates/password-reset.php
+++ b/templates/password-reset.php
@@ -9,7 +9,13 @@
 				<div class="um-field um-field-block um-field-type_block">
 					<div class="um-field-block">
 						<div style="text-align:center;">
-							<?php esc_html_e( 'We have sent you a password reset link to your e-mail. Please check your inbox.', 'ultimate-member' ); ?>
+							<?php
+							if (UM()->options()->get('enable_hide_valid_email_addresses')) {
+								esc_html_e('If an account matching the provided details exists, we will send a password reset link. Please check your inbox.', 'ultimate-member');
+							} else {
+								esc_html_e('We have sent you a password reset link to your e-mail. Please check your inbox.', 'ultimate-member');
+							}
+							?>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
This is a solution for users who don't wish to reveal the existence of an account when attempting a password reset.

It will always redirect to the same landing page, which has slightly modified wording, so that it is valid whether an e-mail is sent or not.

By default this is disabled, so the behaviour will remain consistent for existing users, but a setting has been added to the 'Access' > 'Other' section of the settings page to allow it to be switched on.

I have also included the new phrases in the POT file.