### PR TITLE
Fix text in export and delete requests in Account > Privacy tab

### DIFF
--- a/includes/core/um-actions-account.php
+++ b/includes/core/um-actions-account.php
@@ -678,7 +678,7 @@ function um_after_account_privacy( $args ) {
 		ARRAY_A );
 
 		if ( ! empty( $pending ) && $pending['post_status'] == 'request-pending' ) {
-			echo '<p>' . esc_html__( 'A confirmation email has been sent to your email. Click the link within the email to confirm your export request.', 'ultimate-member' ) . '</p>';
+			echo '<p>' . esc_html__( 'A confirmation email has been sent to your email. Click the link within the email to confirm your deletion request.', 'ultimate-member' ) . '</p>';
 		} elseif ( ! empty( $pending ) && $pending['post_status'] == 'request-confirmed' ) {
 			echo '<p>' . esc_html__( 'The administrator has not yet approved deleting your data. Please expect an email with a link to your data.', 'ultimate-member' ) . '</p>';
 		} else {
@@ -756,7 +756,11 @@ function um_request_user_data() {
 		$answer = esc_html( $request_id->get_error_message() );
 	} else {
 		wp_send_user_request( $request_id );
-		$answer = esc_html__( 'A confirmation email has been sent to your email. Click the link within the email to confirm your export request.', 'ultimate-member' );
+		if ( 'um-export-data' === $request_action ) {
+			$answer = esc_html__( 'A confirmation email has been sent to your email. Click the link within the email to confirm your export request.', 'ultimate-member' );
+		} elseif ( 'um-erase-data' === $request_action ) {
+			$answer = esc_html__( 'A confirmation email has been sent to your email. Click the link within the email to confirm your deletion request.', 'ultimate-member' );
+		}
 	}
 
 	wp_send_json_success( array( 'answer' => $answer ) );


### PR DESCRIPTION
Export text shows to the Delete request text

<img width="871" alt="Screen Shot 2021-12-03 at 8 12 41 PM" src="https://user-images.githubusercontent.com/12200688/144600642-8800666c-de38-4651-9f0c-b02264570141.png">
