### PR TITLE
Support multiple UM and WP roles for a single user.  

### DIFF
--- a/includes/admin/assets/css/um-admin-role-checkbox.css
+++ b/includes/admin/assets/css/um-admin-role-checkbox.css
@@ -1,0 +1,9 @@
+input[type="checkbox"] {    max-width: 1rem; }
+
+label[for="role"],
+select#role,
+label[for="um-role"],
+select#um-role,
+h3#um_user_screen_block,
+div#um_role_selector_wrapper {    display: none; }
+

--- a/includes/admin/assets/js/um-admin-role-wrapper.js
+++ b/includes/admin/assets/js/um-admin-role-wrapper.js
@@ -1,5 +1,15 @@
 jQuery( document ).ready( function() {
+	var row = jQuery('select#role').closest('tr');
+	var clone = row.clone();
+	row.html(jQuery('.um-roles-container tr').html());
+	jQuery('.um-roles-container').remove();
 
+	jQuery('input[name="um_user_roles_general"]').change(function() {
+		var checkedValue = jQuery('input:checkbox:checked').map(function() { return this.value; }).get();
+		jQuery('#um_user_roles_general').val(checkedValue);
+	});
+
+/*  The roles are now checkboxes and there is no longer a separate UM section in the user-edit page.
 	jQuery( '#role' ).on('change', function() {
 
 		if ( typeof um_roles == 'object' ) {
@@ -38,5 +48,5 @@ jQuery( document ).ready( function() {
 			jQuery( '#um_user_screen_block' ).show();
 		}
 	}).trigger('change');
-
+*/
 });

--- a/includes/core/class-roles-capabilities.php
+++ b/includes/core/class-roles-capabilities.php
@@ -170,10 +170,12 @@ if ( ! class_exists( 'um\core\Roles_Capabilities' ) ) {
 			// Validate user id
 			$user = get_userdata( $user_id );
 
+mwi_logger('set_role: entered');
 			// User exists
 			if ( ! empty( $user ) ) {
-				// Get users old UM role
+				// Get users old UM role array
 				$role = UM()->roles()->get_um_user_role( $user_id );
+mwi_logger('set_role: userroles = '.implode($role));
 
 				// User already has this role so no new role is set
 				if ( $new_role === $role || ( ! $this->is_role_custom( $new_role ) && user_can( $user, $new_role ) ) ) {
@@ -539,7 +541,8 @@ if ( ! class_exists( 'um\core\Roles_Capabilities' ) ) {
 				return false;
 			}
 
-			return array_shift( $user_um_roles_array );
+mwi_logger('get_um_user_role Returning : '.implode(',',$user_um_roles_array));
+			return  implode(',',$user_um_roles_array);
 		}
 
 

--- a/includes/core/class-roles-capabilities.php
+++ b/includes/core/class-roles-capabilities.php
@@ -166,32 +166,59 @@ if ( ! class_exists( 'um\core\Roles_Capabilities' ) ) {
 		 * @uses apply_filters() Calls 'um_set_user_role' with the role and user id
 		 * @return string
 		 */
-		function set_role( $user_id, $new_role = '' ) {
+		function set_role( $user_id, $new_roles = array() ) {
 			// Validate user id
 			$user = get_userdata( $user_id );
 
-mwi_logger('set_role: entered');
 			// User exists
 			if ( ! empty( $user ) ) {
-				// Get users old UM role array
-				$role = UM()->roles()->get_um_user_role( $user_id );
-mwi_logger('set_role: userroles = '.implode($role));
+				/* $new_roles is the list of roles we want the user to have.
+				 * $user->roles are the roles the user already has.  We need to remove any roles
+				 * that the user should no longer have, and add roles that the user needs to get
+				 */
+				// Make sure there are no invalid roles provided...
+				$allroles = get_editable_roles();
+				$new_roles = array_intersect( $new_roles, array_keys( $allroles ) );
 
-				// User already has this role so no new role is set
-				if ( $new_role === $role || ( ! $this->is_role_custom( $new_role ) && user_can( $user, $new_role ) ) ) {
-					$new_role = false;
+				// Find roles that might have been deleted and the user should no longer have
+				$roles_to_remove = array_diff( $user->roles,  array_keys( $allroles ) );
+				$user_roles = array_intersect( $user->roles,  array_keys( $allroles ) );
+
+				do_action( 'um_before_user_role_is_changed' );
+
+				if ( ! $new_roles ) {
+					$roles_to_remove=$user->roles;
 				} else {
+					$roles_to_remove = array_merge($roles_to_remove,array_diff( $user_roles, $new_roles ));
+				}
+				foreach ( $roles_to_remove as $role ) {
+					$user->remove_role( $role );
+				}
+				foreach (array_diff($new_roles, $user->roles) as $role) {
+					do_action( 'um_when_role_is_set', $user_id );
+					$user->add_role( $role );
+					do_action( 'um_after_user_role_is_updated', $user_id, $role );
+				} 
+
+				do_action( 'um_after_user_role_is_changed' );
+
+// This whole section below can be removed. since we are doing similar. I haven't done it yet
+// since I am not sure how the hooks are supposed to be used.
+				// User already has this role so no new role is set
+//				if ( $new_role === $role || ( ! $this->is_role_custom( $new_role ) && user_can( $user, $new_role ) ) ) {
+//					$new_role = false;
+//				} else {
 					// Users role is different than the new role
 
 					// Remove the old UM role
-					if ( ! empty( $role ) && $this->is_role_custom( $role ) ) {
-						$user->remove_role( $role );
-					}
+//					if ( ! empty( $role ) && $this->is_role_custom( $role ) ) {
+//						$user->remove_role( $role );
+//					}
 
 					// Add the new role
-					if ( ! empty( $new_role ) ) {
-						$user->add_role( $new_role );
-					}
+//					if ( ! empty( $new_role ) ) {
+//						$user->add_role( $new_role );
+//					}
 
 					/**
 					 * UM hook
@@ -212,7 +239,7 @@ mwi_logger('set_role: userroles = '.implode($role));
 					 * }
 					 * ?>
 					 */
-					do_action( 'um_when_role_is_set', $user_id );
+//					do_action( 'um_when_role_is_set', $user_id );
 					/**
 					 * UM hook
 					 *
@@ -230,9 +257,9 @@ mwi_logger('set_role: userroles = '.implode($role));
 					 * }
 					 * ?>
 					 */
-					do_action( 'um_before_user_role_is_changed' );
+//					do_action( 'um_before_user_role_is_changed' );
 
-					UM()->user()->profile['role'] = $new_role;
+//					UM()->user()->profile['role'] = $new_role;
 
 					/**
 					 * UM hook
@@ -254,9 +281,9 @@ mwi_logger('set_role: userroles = '.implode($role));
 					 * }
 					 * ?>
 					 */
-					do_action( 'um_member_role_upgrade', $role, UM()->user()->profile['role'] );
+//					do_action( 'um_member_role_upgrade', $role, UM()->user()->profile['role'] );
 
-					UM()->user()->update_usermeta_info( 'role' );
+//					UM()->user()->update_usermeta_info( 'role' );
 					/**
 					 * UM hook
 					 *
@@ -274,7 +301,7 @@ mwi_logger('set_role: userroles = '.implode($role));
 					 * }
 					 * ?>
 					 */
-					do_action( 'um_after_user_role_is_changed' );
+//					do_action( 'um_after_user_role_is_changed' );
 					/**
 					 * UM hook
 					 *
@@ -295,11 +322,11 @@ mwi_logger('set_role: userroles = '.implode($role));
 					 * }
 					 * ?>
 					 */
-					do_action( 'um_after_user_role_is_updated', $user_id, $role );
-				}
+//					do_action( 'um_after_user_role_is_updated', $user_id, $role );
+//				}
 			} else {
 				// User does don exist so return false
-				$new_role = false;
+ 				$new_role = false;
 			}
 
 			/**
@@ -325,7 +352,7 @@ mwi_logger('set_role: userroles = '.implode($role));
 			 * }
 			 * ?>
 			 */
-			return apply_filters( 'um_set_user_role', $new_role, $user_id, $user );
+			return apply_filters( 'um_set_user_role', $new_roles, $user_id, $user );
 		}
 
 
@@ -541,7 +568,6 @@ mwi_logger('set_role: userroles = '.implode($role));
 				return false;
 			}
 
-mwi_logger('get_um_user_role Returning : '.implode(',',$user_um_roles_array));
 			return  implode(',',$user_um_roles_array);
 		}
 

--- a/includes/core/class-user.php
+++ b/includes/core/class-user.php
@@ -349,16 +349,15 @@ if ( ! class_exists( 'um\core\User' ) ) {
 		 * @param $result
 		 */
 		function add_um_role_existing_user( $user_id, $result ) {
-mwi_logger('add_um_role_existing_user: ');
 			// Bail if no user ID was passed
 			if ( empty( $user_id ) ) {
 				return;
 			}
 
 			if ( ! empty( $_POST['um-role'] ) && current_user_can( 'promote_users' ) ) {
-				if ( ! user_can( $user_id, sanitize_key( $_POST['um-role'] ) ) ) {
-					UM()->roles()->set_role( $user_id, sanitize_key( $_POST['um-role'] ) );
-				}
+				// $_POST['um-role'] is now an array, so we sanitize each entry
+				$new_roles = array_map( 'sanitize_text_field', wp_unslash( $_POST['um-role'] ) );
+				UM()->roles()->set_role( $user_id, $new_roles );
 			}
 
 			$this->remove_cache( $user_id );
@@ -371,16 +370,16 @@ mwi_logger('add_um_role_existing_user: ');
 		 * @param $user_id
 		 */
 		function add_um_role_wpmu_new_user( $user_id ) {
-mwi_logger('add_um_role_new_user: ');
 			// Bail if no user ID was passed
 			if ( empty( $user_id ) ) {
 				return;
 			}
 
 			if ( ! empty( $_POST['um-role'] ) && current_user_can( 'promote_users' ) ) {
-				if ( ! user_can( $user_id, sanitize_key( $_POST['um-role'] ) ) ) {
-					UM()->roles()->set_role( $user_id, sanitize_key( $_POST['um-role'] ) );
-				}
+				// $_POST['um-role'] is now an array, so we sanitize each entry
+				$new_roles = array_map( 'sanitize_text_field', wp_unslash( $_POST['um-role'] ) );
+				UM()->roles()->set_role( $user_id, $new_roles );
+
 			}
 
 			$this->remove_cache( $user_id );
@@ -644,17 +643,13 @@ mwi_logger('add_um_role_new_user: ');
 			if ( empty( $user_id ) ) {
 				return;
 			}
-
 			$old_roles = $old_data->roles;
-			$userdata  = get_userdata( $user_id );
-			$new_roles = $userdata->roles;
-mwi_logger('profile_update entered with new roles: '.implode(',',$new_roles).'     old roles: '.implode(',',$old_roles));
+
 			if ( is_admin() ) {
 				if ( ! empty( $_POST['um-role'] ) && current_user_can( 'promote_users' ) ) {
-					$new_roles = array_merge( $new_roles, array( sanitize_key( $_POST['um-role'] ) ) );
-					if ( ! user_can( $user_id, sanitize_key( $_POST['um-role'] ) ) ) {
-						UM()->roles()->set_role( $user_id, sanitize_key( $_POST['um-role'] ) );
-					}
+					// $_POST['um-role'] is now an array, so we sanitize each entry
+					$new_roles = array_map( 'sanitize_text_field', wp_unslash( $_POST['um-role'] ) );
+					UM()->roles()->set_role( $user_id, $new_roles );
 				}
 			}
 
@@ -694,7 +689,6 @@ mwi_logger('profile_update entered with new roles: '.implode(',',$new_roles).'  
 		 * @return void
 		 */
 		function profile_form_additional_section( $userdata ) {
-mwi_logger('profile_form_additional_section: ');
 			/**
 			 * UM hook
 			 *
@@ -723,7 +717,6 @@ mwi_logger('profile_form_additional_section: ');
 			 * this is to weed out roles that may have been deleted */
 			$roles = get_editable_roles();
 			$user_roles = ! empty($userdata->roles) ? array_intersect($userdata->roles,array_keys($roles)) : array();
-mwi_logger('profile_form_additional_section: ',implode(',',$user_roles));
 ?>
 <div class="um-roles-container">
 <table class="form-table">
@@ -737,7 +730,7 @@ mwi_logger('profile_form_additional_section: ',implode(',',$user_roles));
 <label for="user_role_<?php echo esc_attr( $role_id ); ?>">
 <input type="checkbox" style="width: 1em;" id="user_role_<?php esc_attr_e( $role_id ); ?>"
        value="<?php esc_attr_e( $role_id ); ?>"
-       name="um_user_roles[]" <?php echo ( ! empty( $user_roles ) && in_array( $role_id, $user_roles ) ) ? ' checked="checked"' : ''; ?> />
+       name="um-role[]" <?php echo ( ! empty( $user_roles ) && in_array( $role_id, $user_roles ) ) ? ' checked="checked"' : ''; ?> />
    <?php esc_html_e( translate_user_role( $role_data['name'] ) ); ?>
 </label>
 <br />

--- a/includes/core/class-user.php
+++ b/includes/core/class-user.php
@@ -349,12 +349,15 @@ if ( ! class_exists( 'um\core\User' ) ) {
 		 * @param $result
 		 */
 		function add_um_role_existing_user( $user_id, $result ) {
-			// Bail if no user ID was passed
-			if ( empty( $user_id ) ) {
-				return;
+			// Bail if no user ID was passed, or the current user cannot prompte users
+			// or the nonce does not check
+			if ( empty( $user_id ) ||
+			    !current_user_can('promote_users') ||
+			    !wp_verify_nonce($_POST['_um_roles_nonce'],'um_set_roles')) {
+				 return;
 			}
 
-			if ( ! empty( $_POST['um-role'] ) && current_user_can( 'promote_users' ) ) {
+			if ( ! empty( $_POST['um-role'] ) ) {
 				// $_POST['um-role'] is now an array, so we sanitize each entry
 				$new_roles = array_map( 'sanitize_text_field', wp_unslash( $_POST['um-role'] ) );
 				UM()->roles()->set_role( $user_id, $new_roles );
@@ -370,12 +373,15 @@ if ( ! class_exists( 'um\core\User' ) ) {
 		 * @param $user_id
 		 */
 		function add_um_role_wpmu_new_user( $user_id ) {
-			// Bail if no user ID was passed
-			if ( empty( $user_id ) ) {
-				return;
+			// Bail if no user ID was passed, or the current user cannot prompte users
+			// or the nonce does not check
+			if ( empty( $user_id ) ||
+			    !current_user_can('promote_users') ||
+			    !wp_verify_nonce($_POST['_um_roles_nonce'],'um_set_roles')) {
+				 return;
 			}
 
-			if ( ! empty( $_POST['um-role'] ) && current_user_can( 'promote_users' ) ) {
+			if ( ! empty( $_POST['um-role'] ) ) {
 				// $_POST['um-role'] is now an array, so we sanitize each entry
 				$new_roles = array_map( 'sanitize_text_field', wp_unslash( $_POST['um-role'] ) );
 				UM()->roles()->set_role( $user_id, $new_roles );
@@ -592,14 +598,17 @@ if ( ! class_exists( 'um\core\User' ) ) {
 		 * @param $user_id
 		 */
 		function user_register_via_admin( $user_id ) {
-
-			if ( empty( $user_id ) ) {
-				return;
+			// Bail if no user ID was passed, or the current user cannot prompte users
+			// or the nonce does not check
+			if ( empty( $user_id ) ||
+			    !current_user_can('promote_users') ||
+			    !wp_verify_nonce($_POST['_um_roles_nonce'],'um_set_roles')) {
+				 return;
 			}
 
 			if ( is_admin() ) {
 				//if there custom 2 role not empty
-				if ( ! empty( $_POST['um-role'] ) && current_user_can( 'promote_users' ) ) {
+				if ( ! empty( $_POST['um-role'] ) ) {
 					$user = get_userdata( $user_id );
 					$user->add_role( sanitize_key( $_POST['um-role'] ) );
 					UM()->user()->profile['role'] = sanitize_key( $_POST['um-role'] );
@@ -639,14 +648,18 @@ if ( ! class_exists( 'um\core\User' ) ) {
 		 * @param \WP_User $old_data
 		 */
 		function profile_update( $user_id, $old_data ) {
-			// Bail if no user ID was passed
-			if ( empty( $user_id ) ) {
-				return;
+			// Bail if no user ID was passed, or the current user cannot prompte users
+			// or the nonce does not check
+			if ( empty( $user_id ) ||
+			    !current_user_can('promote_users') ||
+			    !wp_verify_nonce($_POST['_um_roles_nonce'],'um_set_roles')) {
+				 return;
 			}
+
 			$old_roles = $old_data->roles;
 
 			if ( is_admin() ) {
-				if ( ! empty( $_POST['um-role'] ) && current_user_can( 'promote_users' ) ) {
+				if ( ! empty( $_POST['um-role'] ) ) {
 					// $_POST['um-role'] is now an array, so we sanitize each entry
 					$new_roles = array_map( 'sanitize_text_field', wp_unslash( $_POST['um-role'] ) );
 					UM()->roles()->set_role( $user_id, $new_roles );

--- a/includes/core/class-user.php
+++ b/includes/core/class-user.php
@@ -717,6 +717,9 @@ if ( ! class_exists( 'um\core\User' ) ) {
 			 * this is to weed out roles that may have been deleted */
 			$roles = get_editable_roles();
 			$user_roles = ! empty($userdata->roles) ? array_intersect($userdata->roles,array_keys($roles)) : array();
+			$curruserid=get_current_user_id() ;
+			$curruserpriority=UM()->roles()->get_role_priority(UM()->roles()->get_priority_user_role($curruserid));
+
 ?>
 <div class="um-roles-container">
 <table class="form-table">
@@ -724,7 +727,8 @@ if ( ! class_exists( 'um\core\User' ) ) {
 <td>
 <?php
 			foreach ( $roles as $role_id => $role_data ) {
-				if ( current_user_can( 'promote_users', get_current_user_id() ) ) {
+				if ( current_user_can( 'promote_users', $curruserid) &&
+					$curruserpriority >= UM()->roles()->get_role_priority($role_data['name'])  ) {
 
 ?>
 <label for="user_role_<?php echo esc_attr( $role_id ); ?>">


### PR DESCRIPTION
This change adds code to allow a single user to have many different roles (WP and UM roles) at the same time.  In addition the user no longer must have a WP role (eg. subscriber), and may have only one or more UM roles or any combination of WP and UM roles.

The main thing this change does is update the WP->Users page so that the Role 'select box' is now a list of checkboxes where one or more checks can be done for a single user, and removes the UM Secondary Role dropdown.

Code changed:

1) Updates the 'UM()->roles()->set_role()' code to **accept an array of roles** instead of a single role.  It will then figure out which of the roles in the array may be added (based on role priority), and which roles the user currently has that are no longer in the 'array' and may be removed (again based on role priority).
2) Added 'UM()->roles()->get_role_priority( $role) to get the numerical priority of a given role so that it can be compared.
3) Updates 'UM()->user()->profile_update()' to accept the $_POST of (um-roles) and treat it as an array of values
4) Updates 'UM()->user()->profile_form_additional_section()' to present the list of checkboxes in place of the normal WP role selectbox and remove the UM Secondary Role dropdown as its function is replicated with the checkboxes.

JavaScript and CSS to support the GUI change.

UseCase:
I run a WP site for our organization where all the members of the organization have logins on the WP site.  Most members are normal users and initially I had them be 'subscribers' but later changed to a 'um_org-member'  role since it was more descriptive.  There are also some non-member WP site users who are 'um_security' and some are 'um_bldg-mgr'.  These are not um_org-members and their roles restrict parts of the site that they do not need to access.

Finally some um_org-members have additional roles such as um_board-member and/or um_compliance and/or um_maintenance and/or um_landscape.  Each of the additional roles adds capabilities to that user's login.

For example Alice may be a um_board-member which gives her access to all the functions (um_compliance, um_maintenance, um_landscape) while Bob may be part of the um_maintenance and um_landscape teams but is not a board member nor a um_compliance member.


The code change I added does respect 'role priority' and in my site board-members (priority 10) may 'promote-users' to um_landscape or um_maintenance or um_compliance (all priority 1).  However um_board-members cannot promote users to 'um_SiteEditor' (priority 20), while um_SiteEditor can promote users to board-member.  Neither can promote users to Administrator (priority 100).

The code I wrote does make some significant changes to the GUI (removes the secondary role dropdown), and I wasn't sure what to do with some of the um_code_hooks.  The code may be better suited to an 'extension' but I am a PHP, and WP and UM novice at this point, and it is currently working well for my use case.

In the UM()->roles()->set_role() I left the old code in the file but commented everything out, mainly to preserve the 'hook' locations.  I am not sure who/how these hooks are used:

do_action( 'um_when_role_is_set', $user_id );
do_action( 'um_before_user_role_is_changed' );
do_action( 'um_member_role_upgrade', $role, UM()->user()->profile['role'] );
do_action( 'um_after_user_role_is_changed' );
do_action( 'um_after_user_role_is_updated', $user_id, $role );

Since one 'set_role' call can now do multiple role changes, I suppose these hooks can be called inside the add/remove loops.

I am also not sure what to do about UM()->user()->profile['role'] as it can now have multiple values.  Should this be similar to UM()->user()->profile['wp_role'] which seems to have multiple roles comma separated?

I suppose that UM()->user()->get_role() needs to be updated to handle multiple roles, but I haven't had a need for that yet and don't know where that is used.

