### PR TITLE
Change the word approved to created

### DIFF
--- a/includes/class-config.php
+++ b/includes/class-config.php
@@ -482,7 +482,7 @@ if ( ! class_exists( 'um\Config' ) ) {
 					                   '{user_profile_link}<br /><br />' .
 					                   'Here is the submitted registration form:<br /><br />' .
 					                   '{submitted_registration}',
-					'description'   => __('Whether to receive notification when a new user account is approved','ultimate-member'),
+					'description'   => __('Whether to receive notification when a new user account is created','ultimate-member'),
 					'recipient'   => 'admin',
 					'default_active' => true
 				),


### PR DESCRIPTION
For new user admin notification email description the word approved creates confusion, this should be changed to created
https://secure.helpscout.net/conversation/1779797627/58148/