### PR TITLE
Change the word approved to created

### DIFF
--- a/languages/ultimate-member.pot
+++ b/languages/ultimate-member.pot
@@ -4706,7 +4706,7 @@ msgid "New User Notification"
 msgstr ""
 
 #: includes/class-config.php:485
-msgid "Whether to receive notification when a new user account is approved"
+msgid "Whether to receive notification when a new user account is created"
 msgstr ""
 
 #: includes/class-config.php:491


### PR DESCRIPTION
For new user admin notification email description the word approved creates confusion, this should be changed to created
https://secure.helpscout.net/conversation/1779797627/58148/