### PR TITLE
- Fixed: checkbox field data type on sanitize

### DIFF
--- a/includes/core/class-form.php
+++ b/includes/core/class-form.php
@@ -128,9 +128,9 @@ if ( ! class_exists( 'um\core\Form' ) ) {
 
 					$values_array = $wpdb->get_col(
 						$wpdb->prepare(
-							"SELECT DISTINCT meta_value 
-							FROM $wpdb->usermeta 
-							WHERE meta_key = %s AND 
+							"SELECT DISTINCT meta_value
+							FROM $wpdb->usermeta
+							WHERE meta_key = %s AND
 								  meta_value != ''",
 							$arr_options['post']['child_name']
 						)
@@ -662,7 +662,7 @@ if ( ! class_exists( 'um\core\Form' ) ) {
 										case 'multiselect':
 										case 'radio':
 										case 'checkbox':
-											$form[ $k ] = array_map( 'sanitize_text_field', $form[ $k ] );
+											$form[ $k ] = is_array( $form[ $k ] ) ? array_map( 'sanitize_text_field', $form[ $k ] ) : array( sanitize_text_field( $form[ $k ] ) );
 											break;
 									}
 								}


### PR DESCRIPTION
The function array_map may cause a fatal error if the second argument ($array) is not an array. We must verify input data type before using this function.

**An example of the error:**
2022/04/19 08:56:54 [error] 87392#87392: *76710 FastCGI sent in stderr: "PHP message: PHP Fatal error: Uncaught TypeError: array_map(): Argument #2 ($array) must be of type array, string given in /www/site/wp-content/plugins/ultimate-member/includes/core/class-form.php:665
Stack trace:
#0 /www/site/wp-content/plugins/ultimate-member/includes/core/class-form.php(665): array_map('sanitize_text_f...', 'Yes')
#1 /www/site/wp-content/plugins/ultimate-member/includes/core/class-form.php(422): um\core\Form->sanitize(Array)
#2 /www/site/wp-includes/class-wp-hook.php(307): um\core\Form->form_init('')
#3 /www/site/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters(NULL, Array)
#4 /www/site/wp-includes/plugin.php(474): WP_Hook->do_action(Array)
#5 /www/site/wp-includes/template-loader.php(13): do_action('template_redire...')
#6 /www/site/wp-blog-header.php(19): require_once('/www/site/wp-inc...')
#7 /www/site/index.php(17): require_once('/www/site/wp-blo...') while reading response header from upstream, request: "POST /sas-user/sean.mclaughlin/?um_action=edit HTTP/1.1")
