### PR TITLE
Fix $current_screen

### DIFF
--- a/includes/admin/core/class-admin-enqueue.php
+++ b/includes/admin/core/class-admin-enqueue.php
@@ -657,7 +657,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Enqueue' ) ) {
 			global $wp_version, $current_screen;
 
 			if ( version_compare( $wp_version, '5.0', '>=' ) ) {
-				if ( $current_screen->is_block_editor() ) {
+				if ( isset( $current_screen ) && $current_screen->is_block_editor() ) {
 					$this->load_gutenberg_js();
 					$this->load_gutenberg_shortcode_blocks();
 				}


### PR DESCRIPTION
Fixed error that appears on the printing of cash receipts with the plugin _Point of Sale for WooCommerce_

**Error Details**
An error of type E_ERROR was caused in line 660 of the file /home/thecoinhunter/public_html/wp-content/plugins/ultimate-member/includes/admin/core/class-admin-enqueue.php. Error message: Uncaught Error: Call to a member function is_block_editor() on null in /home/thecoinhunter/public_html/wp-content/plugins/ultimate-member/includes/admin/core/class-admin-enqueue.php:660