### PR TITLE
Fix for the glob function fatal error

### DIFF
--- a/includes/core/class-uploader.php
+++ b/includes/core/class-uploader.php
@@ -383,7 +383,7 @@ if ( ! class_exists( 'um\core\Uploader' ) ) {
 				  ?>
 				 */
 				$movefile = apply_filters( 'um_upload_image_result', $movefile, $user_id, $field_data );
-				
+
 				/**
 				 * Resize and compress images uploaded by the field "Image Upload" without crop.
 				 * Resize and compress images uploaded on Activity wall and Group Discussion wall.
@@ -1361,7 +1361,7 @@ if ( ! class_exists( 'um\core\Uploader' ) ) {
 				}
 			}
 
-			$files = glob( UM()->uploader()->get_upload_base_dir() . $user_id . DIRECTORY_SEPARATOR . '*', GLOB_BRACE );
+			$files = glob( UM()->uploader()->get_upload_base_dir() . $user_id . DIRECTORY_SEPARATOR . '*' );
 			if ( ! empty( $files ) ) {
 				foreach ( $files as $file ) {
 					$str = basename( $file );


### PR DESCRIPTION
The GLOB_BRACE flag is not available on some non GNU systems, like Solaris or Alpine Linux. We should not use it without verification. In this case it is not needed.

**Error details**
Fatal error: Uncaught Error: Undefined constant "um\core\GLOB_BRACE" in /var/www/wp-content/plugins/ultimate-member/includes/core/class-uploader.php:1364