### PR TITLE
Fix the option 'um_options'

### DIFF
--- a/includes/core/class-options.php
+++ b/includes/core/class-options.php
@@ -33,6 +33,9 @@ if ( ! class_exists( 'um\core\Options' ) ) {
 		 */
 		function init_variables() {
 			$this->options = get_option( 'um_options' );
+			if ( ! is_array( $this->options ) ) {
+				$this->options = array();
+			}
 		}
 
 


### PR DESCRIPTION
Fixed PHP warning that appears if the option 'um_options' is not an array.

**Error example:**
Got error 'PHP message: PHP Warning: Illegal string offset 'pages_settings' in /public_html/cms/wp-content/plugins/ultimate-member/includes/core/class-options.php on line 92