### PR TITLE
Fix for Choices Callback option

### DIFF
--- a/includes/admin/core/class-admin-builder.php
+++ b/includes/admin/core/class-admin-builder.php
@@ -618,7 +618,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Builder' ) ) {
 				'field_type' => sanitize_key( $_POST['_type'] ),
 				'form_id'    => absint( $_POST['post_id'] ),
 				'args'       => UM()->builtin()->get_core_field_attrs( sanitize_key( $_POST['_type'] ) ),
-				'post'       => UM()->admin()->sanitize_builder_field_meta( $_POST ),
+				'post'       => UM()->admin()->sanitize_builder_field_meta( wp_unslash( $_POST ) ),
 			);
 
 			/**
@@ -1209,7 +1209,8 @@ if ( ! class_exists( 'um\admin\core\Admin_Builder' ) ) {
 
 			$arr_options = array();
 
-			$um_callback_func = sanitize_key( $_POST['um_option_callback'] );
+			// we can not use sanitize_key bacause it removes backslash needed for namespace.
+			$um_callback_func = sanitize_text_field( wp_unslash( $_POST['um_option_callback'] ) );
 			if ( empty( $um_callback_func ) ) {
 				$arr_options['status'] = 'empty';
 				$arr_options['function_name'] = $um_callback_func;

--- a/includes/core/class-query.php
+++ b/includes/core/class-query.php
@@ -283,13 +283,13 @@ if ( ! class_exists( 'um\core\Query' ) ) {
 
 			/**
 			 * Post meta values are passed through the stripslashes() function upon being stored.
-			 * Function wp_slash() is added to compensate for the call to stripslashes().				 *
+			 * Function wp_slash() is added to compensate for the call to stripslashes().
 			 * @see https://developer.wordpress.org/reference/functions/update_post_meta/
 			 */
 			if ( is_array( $new_value ) ) {
-				foreach ( $new_value as $key => $val ) {
-					if ( is_array( $val ) && array_key_exists( 'custom_dropdown_options_source', $val ) ) {
-						$new_value[ $key ]['custom_dropdown_options_source'] = wp_slash( $val['custom_dropdown_options_source'] );
+				foreach ( $new_value as $k => $v ) {
+					if ( is_array( $v ) && array_key_exists( 'custom_dropdown_options_source', $v ) ) {
+						$new_value[ $k ]['custom_dropdown_options_source'] = wp_slash( $v['custom_dropdown_options_source'] );
 					}
 				}
 			}

--- a/includes/core/class-query.php
+++ b/includes/core/class-query.php
@@ -95,9 +95,9 @@ if ( ! class_exists( 'um\core\Query' ) ) {
 			}
 
 			$pages = $wpdb->get_results(
-				"SELECT * 
-				FROM {$wpdb->posts} 
-				WHERE post_type = 'page' AND 
+				"SELECT *
+				FROM {$wpdb->posts}
+				WHERE post_type = 'page' AND
 				      post_status = 'publish'",
 				OBJECT
 			);
@@ -280,6 +280,20 @@ if ( ! class_exists( 'um\core\Query' ) ) {
 		 * @param $new_value
 		 */
 		function update_attr( $key, $post_id, $new_value ){
+
+			/**
+			 * Post meta values are passed through the stripslashes() function upon being stored.
+			 * Function wp_slash() is added to compensate for the call to stripslashes().				 *
+			 * @see https://developer.wordpress.org/reference/functions/update_post_meta/
+			 */
+			if ( is_array( $new_value ) ) {
+				foreach ( $new_value as $key => $val ) {
+					if ( is_array( $val ) && array_key_exists( 'custom_dropdown_options_source', $val ) ) {
+						$new_value[ $key ]['custom_dropdown_options_source'] = wp_slash( $val['custom_dropdown_options_source'] );
+					}
+				}
+			}
+
 			update_post_meta( $post_id, '_um_' . $key, $new_value );
 		}
 


### PR DESCRIPTION
The dropdown field option **"Choices Callback"** may contain backslashes if the needed callback function is defined inside the namespace.

Post meta values are passed through the `stripslashes()` function upon being stored, so we have to use the function `wp_slash()` to compensate for the call to `stripslashes()`.

**See** https://developer.wordpress.org/reference/functions/update_post_meta/

**Example**
![example with namespace](https://user-images.githubusercontent.com/78854651/172047398-a1c07a92-f0eb-420c-b195-b63d54b2273c.png)