### PR TITLE
Fix fatal error on unset

### DIFF
--- a/includes/core/class-fields.php
+++ b/includes/core/class-fields.php
@@ -308,7 +308,9 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 					// Admin filtering
 					$directory_search_filters = get_post_meta( $directory_id, '_um_search_filters', true );
-					unset( $directory_search_filters[ $id ] );
+					if ( isset( $directory_search_filters[ $id ] ) ) {
+						unset( $directory_search_filters[ $id ] );
+					}
 					update_post_meta( $directory_id, '_um_search_filters', $directory_search_filters );
 
 					// display in tagline


### PR DESCRIPTION
Fix fatal error on unset.

**Error details:**
PHP Fatal error: Uncaught Error: Cannot unset string offsets in D:\web\um\wp-content\plugins\ultimate-member\includes\core\class-fields.php:311