### PR TITLE
Dropdown option value with quotes

### DIFF
--- a/includes/admin/core/class-admin-builder.php
+++ b/includes/admin/core/class-admin-builder.php
@@ -683,7 +683,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Builder' ) ) {
 
 						if ( $new_key == 'options' ) {
 							//$save[ $_metakey ][$new_key] = explode(PHP_EOL, $val);
-							$save[ $_metakey ][ $new_key ] = preg_split( '/[\r\n]+/', $val, -1, PREG_SPLIT_NO_EMPTY );
+							$save[ $_metakey ][ $new_key ] = preg_split( '/[\r\n]+/', wp_unslash( $val ), -1, PREG_SPLIT_NO_EMPTY );
 						} else {
 							$save[ $_metakey ][ $new_key ] = $val;
 						}

--- a/includes/core/class-fields.php
+++ b/includes/core/class-fields.php
@@ -3207,7 +3207,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 							$option_value = $this->filter_field_non_utf8_value( $option_value );
 
-							$output .= '<option value="' . $option_value . '" ';
+							$output .= '<option value="' . esc_attr( $option_value ) . '" ';
 
 							if ( $this->is_selected( $form_key, $option_value, $data ) ) {
 								$output .= 'selected';
@@ -3404,7 +3404,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 							$opt_value = $this->filter_field_non_utf8_value( $opt_value );
 
-							$output .= '<option value="' . $opt_value . '" ';
+							$output .= '<option value="' . esc_attr( $opt_value ) . '" ';
 							if ( $this->is_selected( $key, $opt_value, $data ) ) {
 
 								$output .= 'selected';

--- a/includes/core/class-form.php
+++ b/includes/core/class-form.php
@@ -438,7 +438,7 @@ if ( ! class_exists( 'um\core\Form' ) ) {
 				 * }
 				 * ?>
 				 */
-				$this->post_form = apply_filters( 'um_submit_post_form', $_POST );
+				$this->post_form = apply_filters( 'um_submit_post_form', wp_unslash( $_POST ) );
 
 				if ( isset( $this->post_form[ UM()->honeypot ] ) && '' !== $this->post_form[ UM()->honeypot ] ) {
 					wp_die( esc_html__( 'Hello, spam bot!', 'ultimate-member' ) );


### PR DESCRIPTION
Dropdown fields may work wrong if their options have values with quotes.
We have to escape option values on output and unslash input data on submit.
This is a possible solution.

**Screenshots:**
Image 01 - The field example
![001](https://user-images.githubusercontent.com/78854651/181846295-9d7d4b03-0bbc-420f-b111-99e185e079aa.png)

Image 02 - The issue example
![002](https://user-images.githubusercontent.com/78854651/181846305-9dc2102e-b666-4d3f-9f08-4d64c54d902c.png)