### PR TITLE
Fix error in url field

### DIFF
--- a/includes/core/class-form.php
+++ b/includes/core/class-form.php
@@ -653,7 +653,7 @@ if ( ! class_exists( 'um\core\Form' ) ) {
 										case 'url':
 											$f = UM()->builtin()->get_a_field( $k );
 
-											if ( array_key_exists( 'match', $f ) && array_key_exists( 'advanced', $f ) && 'social' === $f['advanced'] ) {
+											if ( is_array( $f ) && array_key_exists( 'match', $f ) && array_key_exists( 'advanced', $f ) && 'social' === $f['advanced'] ) {
 												$v = sanitize_text_field( $form[ $k ] );
 
 												// Make a proper social link


### PR DESCRIPTION
Added data type check for "url" field when sanitise input. The field data must be an array. Otherwise, a fatal error occurs.