### PR TITLE
Fixed the attachment error

### DIFF
--- a/includes/core/class-access.php
+++ b/includes/core/class-access.php
@@ -59,10 +59,6 @@ if ( ! class_exists( 'um\core\Access' ) ) {
 			// change the excerpt of the restricted post
 			add_filter( 'get_the_excerpt', array( &$this, 'filter_restricted_post_excerpt' ), 999999, 2 );
 
-			// filter attachment
-			add_filter( 'wp_get_attachment_url', array( &$this, 'filter_attachment' ), 99, 2 );
-			add_filter( 'has_post_thumbnail', array( &$this, 'filter_post_thumbnail' ), 99, 3 );
-
 			// comments queries
 			add_action( 'pre_get_comments', array( &$this, 'exclude_posts_comments' ), 99, 1 );
 			add_filter( 'wp_count_comments', array( &$this, 'custom_comments_count_handler' ), 99, 2 );
@@ -84,6 +80,21 @@ if ( ! class_exists( 'um\core\Access' ) ) {
 			add_action( 'um_access_check_global_settings', array( &$this, 'um_access_check_global_settings' ) );
 
 			add_action( 'plugins_loaded', array( &$this, 'disable_restriction_pre_queries' ), 1 );
+
+			// Init hooks that use pluggable functions.
+			add_action( 'init', array( &$this, 'initialize_hooks' ), 5 );
+		}
+
+
+		/**
+		 * Init hooks that use pluggable functions.
+		 */
+		public function initialize_hooks() {
+
+			// filter attachment
+			add_filter( 'wp_get_attachment_url', array( &$this, 'filter_attachment' ), 99, 2 );
+			add_filter( 'has_post_thumbnail', array( &$this, 'filter_post_thumbnail' ), 99, 3 );
+
 		}
 
 
@@ -244,11 +255,11 @@ if ( ! class_exists( 'um\core\Access' ) ) {
 					global $wpdb;
 
 					$terms = $wpdb->get_results(
-						"SELECT tm.term_id AS term_id, 
-					        tt.taxonomy AS taxonomy 
-					FROM {$wpdb->termmeta} tm 
-					LEFT JOIN {$wpdb->term_taxonomy} tt ON tt.term_id = tm.term_id 
-					WHERE tm.meta_key = 'um_content_restriction' AND 
+						"SELECT tm.term_id AS term_id,
+					        tt.taxonomy AS taxonomy
+					FROM {$wpdb->termmeta} tm
+					LEFT JOIN {$wpdb->term_taxonomy} tt ON tt.term_id = tm.term_id
+					WHERE tm.meta_key = 'um_content_restriction' AND
 					      tt.taxonomy IN('" . implode( "','", $restricted_taxonomies ) . "')",
 						ARRAY_A
 					);
@@ -889,9 +900,9 @@ if ( ! class_exists( 'um\core\Access' ) ) {
 			foreach ( $restricted_posts as $k => $post_type ) {
 				if ( 'closed' === get_default_comment_status( $post_type ) ) {
 					$open_comments = $wpdb->get_var( $wpdb->prepare(
-						"SELECT ID 
-						FROM {$wpdb->posts} 
-						WHERE post_type = %s AND 
+						"SELECT ID
+						FROM {$wpdb->posts}
+						WHERE post_type = %s AND
 						      comment_status != 'closed'",
 						$post_type
 					) );


### PR DESCRIPTION
A fatal error may occur due to the conflict with third-party plugins that retrieves an attachment before pluggable functions in the WordPress core are loaded. This pull request contains suggested solution.

**Example:** a conflict with the [Yet Another Stars Rating](https://wordpress.org/plugins/yet-another-stars-rating/) plugin.

**Error details:**
```
[04-Jan-2023 18:45:45 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function wp_get_current_user() in D:\web\um\wp-includes\capabilities.php:873
Stack trace:
#0 D:\web\um\wp-content\plugins\ultimate-member\includes\core\class-access.php(784): current_user_can('administrator')
#1 D:\web\um\wp-includes\class-wp-hook.php(308): um\core\Access->filter_attachment('http://um/wp-co...', 988)
#2 D:\web\um\wp-includes\plugin.php(205): WP_Hook->apply_filters('http://um/wp-co...', Array)
#3 D:\web\um\wp-includes\post.php(6688): apply_filters('wp_get_attachme...', 'http://um/wp-co...', 988)
#4 D:\web\um\wp-includes\media.php(213): wp_get_attachment_url(988)
#5 D:\web\um\wp-includes\media.php(954): image_downsize('988', 'full')
#6 D:\web\um\wp-includes\media.php(1136): wp_get_attachment_image_src('988', 'full', false)
#7 D:\web\um\wp-includes\general-template.php(961): wp_get_attachment_image_url('988', 'full')
#8 D:\web\um\wp-content\plugins\yet-another-stars-rating\includes\classes\YasrSettingsValues.php(95): get_site_icon_url()
#9 D:\web\um\wp-content\plugins\yet-another-stars-rating\includes\classes\YasrSettingsValues.php(22): YasrSettingsValues->defaultValuesGeneral()
#10 D:\web\um\wp-content\plugins\yet-another-stars-rating\includes\yasr-includes-init.php(67): YasrSettingsValues->getGeneralSettings()
#11 D:\web\um\wp-content\plugins\yet-another-stars-rating\yet-another-stars-rating.php(121): require('D:\\web\\um\\wp-co...')
#12 D:\web\um\wp-settings.php(447): include_once('D:\\web\\um\\wp-co...')
#13 D:\web\um\wp-config.php(93): require_once('D:\\web\\um\\wp-se...')
#14 D:\web\um\wp-load.php(50): require_once('D:\\web\\um\\wp-co...')
#15 D:\web\um\wp-admin\admin.php(34): require_once('D:\\web\\um\\wp-lo...')
#16 D:\web\um\wp-admin\plugins.php(10): require_once('D:\\web\\um\\wp-ad...')
```