### PR TITLE
Fix php warning if empty password

### DIFF
--- a/includes/core/um-actions-form.php
+++ b/includes/core/um-actions-form.php
@@ -620,7 +620,7 @@ function um_submit_form_errors_hook_( $args ) {
 					}
 				}
 
-				if ( isset( $array['force_good_pass'] ) && $array['force_good_pass'] == 1 ) {
+				if ( isset( $array['force_good_pass'] ) && $array['force_good_pass'] && ! empty( $args['user_password'] ) ) {
 					if ( isset( $args['user_login'] ) && strpos( strtolower( $args['user_login'] ), strtolower( $args['user_password'] )  ) > -1 ) {
 						UM()->form()->add_error( 'user_password', __( 'Your password cannot contain the part of your username', 'ultimate-member' ));
 					}
@@ -878,7 +878,7 @@ function um_submit_form_errors_hook_( $args ) {
 								}
 							}
 							break;
-							
+
 						case 'alphabetic':
 
 							if ( $args[ $key ] != '' ) {
@@ -886,7 +886,7 @@ function um_submit_form_errors_hook_( $args ) {
 								if ( ! preg_match( '/^\p{L}+$/u', str_replace( ' ', '', $args[ $key ] ) ) ) {
 									UM()->form()->add_error( $key, __( 'You must provide alphabetic letters', 'ultimate-member' ) );
 								}
-								
+
 							}
 
 							break;


### PR DESCRIPTION
Fix PHP Warning that may appear if the registration form is submitted with the empty "Password" field.

Warning example:
```
[09-Jan-2023 11:58:46 UTC] PHP Warning: strpos(): Empty needle in /public_html/um.loc/wp-content/plugins/ultimate-member/includes/core/um-actions-form.php on line 624
[09-Jan-2023 11:58:46 UTC] PHP Warning: strpos(): Empty needle in /public_html/um.loc/wp-content/plugins/ultimate-member/includes/core/um-actions-form.php on line 628
```