### PR TITLE
social links colors

### DIFF
--- a/includes/core/class-builtin.php
+++ b/includes/core/class-builtin.php
@@ -1067,9 +1067,11 @@ if ( ! class_exists( 'um\core\Builtin' ) ) {
 					'editable'   => 1,
 					'url_target' => '_blank',
 					'url_rel'    => 'nofollow',
+					'icon'       => 'um-icon-ios-musical-note',
 					'validate'   => 'tiktok_url',
 					'url_text'   => 'TikTok',
 					'advanced'   => 'social',
+					'color'      => '#000000',
 					'match'      => 'https://tiktok.com/@',
 				),
 
@@ -1087,6 +1089,7 @@ if ( ! class_exists( 'um\core\Builtin' ) ) {
 					'validate'   => 'twitch_url',
 					'url_text'   => 'Twitch',
 					'advanced'   => 'social',
+					'color'      => '#6441a5',
 					'match'      => 'https://twitch.tv/',
 				),
 
@@ -1104,6 +1107,7 @@ if ( ! class_exists( 'um\core\Builtin' ) ) {
 					'validate'   => 'reddit_url',
 					'url_text'   => 'Reddit',
 					'advanced'   => 'social',
+					'color'      => '#ff4500',
 					'match'      => 'https://www.reddit.com/user/',
 				),
 


### PR DESCRIPTION
Fixed colors for social links in the profile header: TikTok, Twitch, Reddit.

**Screenshots:**
Image 1 - Current view.
![social links (issue)](https://user-images.githubusercontent.com/78854651/219753148-7c0c4071-c138-4874-9e9d-28ba709f4c29.PNG)

Image 2 - Fixed view.
![social links (fixed)](https://user-images.githubusercontent.com/78854651/219753175-ad5d95d3-6952-4a77-89fc-58869ef9eda3.PNG)