### PR TITLE
Avoid indexing profile by search engines

### DIFF
--- a/includes/admin/templates/role/profile.php
+++ b/includes/admin/templates/role/profile.php
@@ -53,7 +53,7 @@
 					'0' => __( 'No', 'ultimate-member' ),
 					'1' => __( 'Yes', 'ultimate-member' ),
 				],
-				'value'     => ! empty( $role['_um_profile_noindex'] ) ? $role['_um_profile_noindex'] : '',
+				'value'     => array_key_exists( '_um_profile_noindex', $role ) ? $role['_um_profile_noindex'] : '',
 			)
 		)
 	) )->render_form(); ?>

--- a/includes/core/class-user.php
+++ b/includes/core/class-user.php
@@ -1922,16 +1922,16 @@ if ( ! class_exists( 'um\core\User' ) ) {
 			}
 
 			if ( ! $profile_noindex ) {
-				$role = UM()->roles()->get_priority_user_role( $user_id );
+				$role        = UM()->roles()->get_priority_user_role( $user_id );
 				$permissions = UM()->roles()->role_data( $role );
 
-				if ( isset( $permissions['profile_noindex'] ) && (bool) $permissions['profile_noindex'] ) {
+				if ( isset( $permissions['profile_noindex'] ) && '' !== $permissions['profile_noindex'] ) {
 					// Setting "Avoid indexing profile by search engines" in [wp-admin > Ultimate Member > User Roles > Edit Role]
-					$profile_noindex = true;
+					$profile_noindex = (bool) $permissions['profile_noindex'];
 
-				} elseif ( ( ! isset( $permissions['profile_noindex'] ) || $permissions['profile_noindex'] === '' ) && (bool) UM()->options()->get( 'profile_noindex' ) ) {
+				} else {
 					// Setting "Avoid indexing profile by search engines" in [wp-admin > Ultimate Member > Settings > General > Users]
-					$profile_noindex = true;
+					$profile_noindex = (bool) UM()->options()->get( 'profile_noindex' );
 
 				}
 			}


### PR DESCRIPTION
Fixed role setting "Avoid indexing profile by search engines".

This setting has three options: "Default", "No", "Yes". The core version 2.5.4 displays and uses the "No" option wrong.