### PR TITLE
Password with quotes

### DIFF
--- a/includes/core/class-account.php
+++ b/includes/core/class-account.php
@@ -368,7 +368,7 @@ if ( ! class_exists( 'um\core\Account' ) ) {
 
 			if ( um_submitting_account_page() ) {
 
-				UM()->form()->post_form = $_POST;
+				UM()->form()->post_form = wp_unslash( $_POST );
 
 				/**
 				 * UM hook

--- a/includes/core/class-password.php
+++ b/includes/core/class-password.php
@@ -330,7 +330,7 @@ if ( ! class_exists( 'um\core\Password' ) ) {
 			}
 
 			if ( $this->is_reset_request() ) {
-				UM()->form()->post_form = $_POST;
+				UM()->form()->post_form = wp_unslash( $_POST );
 
 				if ( empty( UM()->form()->post_form['mode'] ) ) {
 					UM()->form()->post_form['mode'] = 'password';
@@ -382,7 +382,7 @@ if ( ! class_exists( 'um\core\Password' ) ) {
 			}
 
 			if ( $this->is_change_request() ) {
-				UM()->form()->post_form = $_POST;
+				UM()->form()->post_form = wp_unslash( $_POST );
 
 				/**
 				 * UM hook


### PR DESCRIPTION
The plugin can not change the password with quotes properly. This happens because WordPress adds slashes before quotes in input data. 
The plugin uses the recommended function `wp_unslash` to remove slashes from input data on registration and login, but does not do this on the Change Password.
I propose to use the `wp_unslash` function to remove slashes from input data on the Change Password.