### PR TITLE
Create custom table for usermeta

### DIFF
--- a/includes/admin/core/class-admin-settings.php
+++ b/includes/admin/core/class-admin-settings.php
@@ -222,6 +222,16 @@ if ( ! class_exists( 'um\admin\core\Admin_Settings' ) ) {
 					$values[] = $wpdb->prepare( '(%d, %s, %s)', $metarow['user_id'], $metarow['meta_key'], $metarow['meta_value'] );
 				}
 
+				// maybe create table.
+				$table_name = $wpdb->prefix . 'um_metadata';
+				$query      = $wpdb->prepare(
+					'SHOW TABLES LIKE %s',
+					$wpdb->esc_like( $table_name )
+				);
+				if ( $wpdb->get_var( $query ) !== $table_name ) {
+					UM()->setup()->create_db();
+				}
+
 				if ( ! empty( $values ) ) {
 					$wpdb->query(
 						"INSERT INTO


### PR DESCRIPTION
The plugin copies data from the default database tables `{$table_prefix}users` and `{$table_prefix}usermeta` to the custom database table `{$table_prefix}um_metadata` when admin turn on the **Enable custom table for usermeta** setting and run the upgrade process. See https://docs.ultimatemember.com/article/1541-meta-table-for-member-directories

But the update process does not work if the database table `{$table_prefix}um_metadata` does not exist. I propose to check whether the table exists and create a table if it does not exist before writing data into this table. 