### PR TITLE
- removed predefined field Google+

### DIFF
--- a/includes/core/class-builtin.php
+++ b/includes/core/class-builtin.php
@@ -949,24 +949,6 @@ if ( ! class_exists( 'um\core\Builtin' ) ) {
 					'match' => 'https://linkedin.com/',
 				),
 
-				'googleplus' => array(
-					'title' => __('Google+','ultimate-member'),
-					'metakey' => 'googleplus',
-					'type' => 'url',
-					'label' => __('Google+','ultimate-member'),
-					'required' => 0,
-					'public' => 1,
-					'editable' => 1,
-					'url_target' => '_blank',
-					'url_rel' => 'nofollow',
-					'icon' => 'um-faicon-google-plus',
-					'validate' => 'google_url',
-					'url_text' => 'Google+',
-					'advanced' => 'social',
-					'color' => '#dd4b39',
-					'match' => 'https://google.com/+',
-				),
-
 				'instagram' => array(
 					'title' => __('Instagram','ultimate-member'),
 					'metakey' => 'instagram',
@@ -1522,7 +1504,6 @@ if ( ! class_exists( 'um\core\Builtin' ) ) {
 			$array['alpha_numeric']            = __('Alpha-numeric value','ultimate-member');
 			$array['english']                  = __('English letters only','ultimate-member');
 			$array['facebook_url']             = __('Facebook URL','ultimate-member');
-			$array['google_url']               = __('Google+ URL','ultimate-member');
 			$array['instagram_url']            = __('Instagram URL','ultimate-member');
 			$array['linkedin_url']             = __('LinkedIn URL','ultimate-member');
 			$array['vk_url']                   = __('VKontakte URL','ultimate-member');

--- a/includes/core/um-actions-form.php
+++ b/includes/core/um-actions-form.php
@@ -746,12 +746,6 @@ function um_submit_form_errors_hook_( $args ) {
 							}
 							break;
 
-						case 'google_url':
-							if ( ! UM()->validation()->is_url( $args[ $key ], 'plus.google.com' ) ) {
-								UM()->form()->add_error( $key, sprintf( __( 'Please enter a valid %s username or profile URL', 'ultimate-member' ), $array['label'] ) );
-							}
-							break;
-
 						case 'linkedin_url':
 							if ( ! UM()->validation()->is_url( $args[ $key ], 'linkedin.com' ) ) {
 								UM()->form()->add_error( $key, sprintf( __( 'Please enter a valid %s username or profile URL', 'ultimate-member' ), $array['label'] ) );

--- a/includes/core/um-filters-fields.php
+++ b/includes/core/um-filters-fields.php
@@ -432,7 +432,6 @@ function um_profile_field_filter_hook__( $value, $data, $type = '' ) {
 				if ( $data['validate'] == 'facebook_url' ) 		$value = 'https://facebook.com/' . $value;
 				if ( $data['validate'] == 'twitter_url' ) 		$value = 'https://twitter.com/' . $value;
 				if ( $data['validate'] == 'linkedin_url' ) 		$value = 'https://linkedin.com/' . $value;
-				if ( $data['validate'] == 'googleplus_url' ) 	$value = 'https://plus.google.com/' . $value;
 				if ( $data['validate'] == 'instagram_url' ) 	$value = 'https://instagram.com/' . $value;
 				if ( $data['validate'] == 'tiktok_url' ) 		$value = 'https://tiktok.com/' . $value;
 				if ( $data['validate'] == 'twitch_url' ) 		$value = 'https://twitch.tv/' . $value;


### PR DESCRIPTION
[Google+](https://plus.google.com/) is no longer available for consumer (personal) and brand accounts.
The predefined field **Google+** in the **Fields Manager** has to be removed since it is useless now.