### PR TITLE
Support button element for info_text field type in settings

### DIFF
--- a/includes/admin/core/class-admin-forms.php
+++ b/includes/admin/core/class-admin-forms.php
@@ -125,6 +125,9 @@ if ( ! class_exists( 'um\admin\core\Admin_Forms' ) ) {
 							'target' => array(),
 							'class' => array(),
 						),
+						'button' => array(
+							'class' => array(),
+						),
 						'i' => array(
 							'class' => array(),
 						),


### PR DESCRIPTION
- This allows the info_text field to display a button element. Button element is used for Stripe's Connect/Disconnect functionality. The issue with anchor tag is, it requires to deattach the onclick function before you can disable it. With button, you only need to add an attribute 'disabled' to prevent the js function from triggering