### PR TITLE
Fix url_target attribute for social fields not being taken into account

### DIFF
--- a/includes/core/class-fields.php
+++ b/includes/core/class-fields.php
@@ -135,7 +135,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					?>
 
 					<a href="<?php echo esc_url( um_filtered_social_link( $k, $match ) ); ?>"
-					   style="background: <?php echo esc_attr( $arr['color'] ); ?>;" target="_blank" class="um-tip-n"
+					   style="background: <?php echo esc_attr( $arr['color'] ); ?>;" target="<?php echo esc_attr( $arr['url_target'] ?? "_blank" ); ?>" class="um-tip-n"
 					   title="<?php echo esc_attr( $arr['title'] ); ?>"><i class="<?php echo esc_attr( $arr['icon'] ); ?>"></i></a>
 
 					<?php


### PR DESCRIPTION
When adding custom social fields, the documentation shows it's possible to set a `url_target` for the field. 
For my personal use I wanted to have it set to `_self` but it never was applied. Today when I was trying to figure out a shortcode to display the social fields anywhere, I found the function that displays the social fields and while reading through it, I noticed that the target attribute of the anchor element wasn't reading the `url_target` item and always set it to `_blank`. 
I added a ternary operator to either use the set `url_target` or fallback to the default `_blank`.