### PR TITLE
Profile form fields disabled in edit mode

### DIFF
--- a/includes/core/class-fields.php
+++ b/includes/core/class-fields.php
@@ -3626,7 +3626,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 								$class  = 'um-icon-android-radio-button-off';
 							}
 
-							if ( empty( $data['editable'] ) ) {
+							if ( array_key_exists( 'editable', $data ) && empty( $data['editable'] ) ) {
 								$col_class .= ' um-field-radio-state-disabled';
 							}
 
@@ -3745,7 +3745,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 							$class  = 'um-icon-android-checkbox-outline-blank';
 						}
 
-						if ( empty( $data['editable'] ) ) {
+						if ( array_key_exists( 'editable', $data ) && empty( $data['editable'] ) ) {
 							$col_class .= ' um-field-radio-state-disabled';
 						}
 

--- a/includes/core/class-fields.php
+++ b/includes/core/class-fields.php
@@ -2177,7 +2177,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 			if ( true === $this->editing && 'profile' === $this->set_mode ) {
 				if ( ! UM()->roles()->um_user_can( 'can_edit_everyone' ) ) {
-					if ( empty( $data['editable'] ) ) {
+					if ( array_key_exists( 'editable', $data ) && empty( $data['editable'] ) ) {
 						$disabled = ' disabled="disabled" ';
 					}
 				}

--- a/includes/um-short-functions.php
+++ b/includes/um-short-functions.php
@@ -1667,7 +1667,7 @@ function um_can_edit_field( $data ) {
 			$can_edit = false;
 		} else {
 			if ( ! UM()->roles()->um_user_can( 'can_edit_everyone' ) ) {
-				if ( empty( $data['editable'] ) ) {
+				if ( array_key_exists( 'editable', $data ) && empty( $data['editable'] ) ) {
 					$can_edit = false;
 				} else {
 					if ( ! um_is_user_himself() ) {


### PR DESCRIPTION
Fixed the field "Can user edit this field?" (editable) setting:
- make a new field editable by default.
- check that the `editable` setting exists before use it.