### PR TITLE
Aria accessibility attributes on form errors

### DIFF
--- a/includes/admin/core/class-admin-metabox.php
+++ b/includes/admin/core/class-admin-metabox.php
@@ -2378,15 +2378,21 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 					break;
 
 				case '_editable':
+					// Make a new field editable by default.
+					if ( false === $this->in_edit ) {
+						$this->edit_mode_value = true;
+					}
+
+					if ( empty( $this->edit_mode_value ) ) {
+						$this->edit_mode_value = false;
+					}
 					?>
 
 					<div class="um-admin-tri">
-
-						<p><label for="_editable"><?php _e( 'Can user edit this field?', 'ultimate-member' ) ?> <?php UM()->tooltip( __( 'This option allows you to set whether or not the user can edit the information in this field. The site admin can edit all fields regardless of the option set here.', 'ultimate-member' ) ); ?></label>
+						<p><label for="_editable"><?php esc_html_e( 'Can user edit this field?', 'ultimate-member' ); ?> <?php UM()->tooltip( __( 'This option allows you to set whether or not the user can edit the information in this field. The site admin can edit all fields regardless of the option set here.', 'ultimate-member' ) ); ?></label>
 							<input type="hidden" name="_editable" id="_editable_hidden" value="0" />
-							<input type="checkbox" name="_editable" id="_editable" value="1" <?php checked( null === $this->edit_mode_value || $this->edit_mode_value ) ?> />
+							<input type="checkbox" name="_editable" id="_editable" value="1" <?php checked( $this->edit_mode_value ); ?> />
 						</p>
-
 					</div>
 
 					<?php

--- a/includes/core/class-account.php
+++ b/includes/core/class-account.php
@@ -567,7 +567,7 @@ if ( ! class_exists( 'um\core\Account' ) ) {
 		function get_tab_fields( $id, $shortcode_args ) {
 			$output = null;
 
-			UM()->fields()->set_id = $id;
+			UM()->fields()->set_id = absint( $id );
 			UM()->fields()->set_mode = 'account';
 			UM()->fields()->editing = true;
 

--- a/includes/core/class-fields.php
+++ b/includes/core/class-fields.php
@@ -508,25 +508,25 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 		 *
 		 * @return string
 		 */
-		public function field_error( $text, $force_show = false ) {
-
+		public function field_error( $text, $input_id, $force_show = false ) {
 			if ( empty( $text ) ) {
 				return '';
 			}
 
 			if ( $force_show ) {
-				$output = '<div class="um-field-error"><span class="um-field-arrow"><i class="um-faicon-caret-up"></i></span>' . wp_kses( $text, UM()->get_allowed_html( 'templates' ) ) . '</div>';
+				$output = '<div class="um-field-error" id="error-for-' . $input_id . '"><span class="um-field-arrow"><i class="um-faicon-caret-up"></i></span>' . wp_kses( $text, UM()->get_allowed_html( 'templates' ) ) . '</div>';
 				return $output;
 			}
 
-			if ( isset( $this->set_id ) && UM()->form()->processing === $this->set_id ) {
-				$output = '<div class="um-field-error"><span class="um-field-arrow"><i class="um-faicon-caret-up"></i></span>' . wp_kses( $text, UM()->get_allowed_html( 'templates' ) ) . '</div>';
+			if ( isset( $this->set_id ) && UM()->form()->processing == $this->set_id ) {
+
+				$output = '<div class="um-field-error" id="error-for-' . $input_id . '"><span class="um-field-arrow"><i class="um-faicon-caret-up"></i></span>' . wp_kses( $text, UM()->get_allowed_html( 'templates' ) ) . '</div>';
 			} else {
 				$output = '';
 			}
 
 			if ( ! UM()->form()->processing ) {
-				$output = '<div class="um-field-error"><span class="um-field-arrow"><i class="um-faicon-caret-up"></i></span>' . wp_kses( $text, UM()->get_allowed_html( 'templates' ) ) . '</div>';
+				$output = '<div class="um-field-error" id="error-for-' . $input_id . '"><span class="um-field-arrow"><i class="um-faicon-caret-up"></i></span>' . wp_kses( $text, UM()->get_allowed_html( 'templates' ) ) . '</div>';
 			}
 
 			return $output;
@@ -2055,6 +2055,10 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 			return apply_filters( 'um_field_non_utf8_value', $option_value );
 		}
 
+		function aria_valid_attributes($is_valid, $field_id){
+			return 'aria-invalid="' . ($is_valid ? 'true" aria-errormessage="error-for-' . esc_attr( $field_id ) : 'false') . '"';
+		}
+
 
 		/**
 		 * Getting the fields that need to be disabled in edit mode (profile)
@@ -2325,7 +2329,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					$field_name  = $key . $form_suffix;
 					$field_value = $this->field_value( $key, $default, $data );
 
-					$output .= '<input ' . $disabled . ' class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" />
+					$output .= '<input ' . $disabled . ' class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '"' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . '/>
 
 						</div>';
 
@@ -2334,7 +2338,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					}
 
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_name ) );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -2359,7 +2363,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					$field_name  = $key . $form_suffix;
 					$field_value = $this->field_value( $key, $default, $data );
 
-					$output .= '<input ' . $disabled . ' autocomplete="' . esc_attr( $autocomplete ) . '" class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" />
+					$output .= '<input ' . $disabled . ' autocomplete="' . esc_attr( $autocomplete ) . '" class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '"' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . ' />
 
 						</div>';
 
@@ -2368,7 +2372,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					}
 
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_name ) );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -2400,12 +2404,12 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					$field_name  = $key . $form_suffix;
 					$field_value = $this->field_value( $key, $default, $data );
 
-					$output .= '<input ' . $disabled . ' class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="number" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" ' . $number_limit . ' />
+					$output .= '<input ' . $disabled . ' class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="number" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" ' . $number_limit . ' ' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . ' />
 
 						</div>';
 
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_name ) );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -2436,18 +2440,18 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 						if ( UM()->options()->get( 'toggle_password' ) ) {
 							$output .= '<div class="um-field-area-password">
-									<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" />
+									<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . ' />
 									<span class="um-toggle-password"><i class="um-icon-eye"></i></span>
 								</div>
 							</div>';
 						} else {
-							$output .= '<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" />
+							$output .= '<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . ' />
 
 							</div>';
 						}
 
 						if ( $this->is_error( $key ) ) {
-							$output .= $this->field_error( $this->show_error( $key ) );
+							$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_name ) );
 						} elseif ( $this->is_notice( $key ) ) {
 							$output .= $this->field_notice( $this->show_notice( $key ) );
 						}
@@ -2474,18 +2478,18 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 							if ( UM()->options()->get( 'toggle_password' ) ) {
 								$output .= '<div class="um-field-area-password">
-										<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" />
+										<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . ' />
 										<span class="um-toggle-password"><i class="um-icon-eye"></i></span>
 									</div>
 								</div>';
 							} else {
-								$output .= '<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" />
+								$output .= '<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . ' />
 
 								</div>';
 							}
 
 							if ( $this->is_error( $key ) ) {
-								$output .= $this->field_error( $this->show_error( $key ) );
+								$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_name ) );
 							} elseif ( $this->is_notice( $key ) ) {
 								$output .= $this->field_notice( $this->show_notice( $key ) );
 							}
@@ -2522,18 +2526,18 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 						$field_value = $this->field_value( $key, $default, $data );
 						if ( UM()->options()->get( 'toggle_password' ) ) {
 							$output .= '<div class="um-field-area-password">
-									<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $name ) . '" id="' . esc_attr( $key . $form_suffix ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" />
+									<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $name ) . '" id="' . esc_attr( $key . $form_suffix ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $key . $form_suffix) . ' />
 									<span class="um-toggle-password"><i class="um-icon-eye"></i></span>
 								</div>
 							</div>';
 						} else {
-							$output .= '<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $name ) . '" id="' . esc_attr( $key . $form_suffix ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" />
+							$output .= '<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $name ) . '" id="' . esc_attr( $key . $form_suffix ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $key . $form_suffix) . ' />
 
 							</div>';
 						}
 
 						if ( $this->is_error( $key ) ) {
-							$output .= $this->field_error( $this->show_error( $key ) );
+							$output .= $this->field_error( $this->show_error( $key ), esc_attr( $key . $form_suffix ) );
 						} elseif ( $this->is_notice( $key ) ) {
 							$output .= $this->field_notice( $this->show_notice( $key ) );
 						}
@@ -2576,15 +2580,15 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 							}
 
 							if ( UM()->options()->get( 'toggle_password' ) ) {
-								$output .= '<div class="um-field-area-password"><input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $name ) . '" id="' . esc_attr( $key . $form_suffix ) . '" value="' . esc_attr( $this->field_value( $key, $default, $data ) ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" /><span class="um-toggle-password"><i class="um-icon-eye"></i></span></div>';
+								$output .= '<div class="um-field-area-password"><input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $name ) . '" id="' . esc_attr( $key . $form_suffix ) . '" value="' . esc_attr( $this->field_value( $key, $default, $data ) ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $key . $form_suffix) . ' /><span class="um-toggle-password"><i class="um-icon-eye"></i></span></div>';
 							} else {
-								$output .= '<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $name ) . '" id="' . esc_attr( $key . $form_suffix ) . '" value="' . esc_attr( $this->field_value( $key, $default, $data ) ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" />';
+								$output .= '<input class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $name ) . '" id="' . esc_attr( $key . $form_suffix ) . '" value="' . esc_attr( $this->field_value( $key, $default, $data ) ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $key . $form_suffix) . ' />';
 							}
 
 							$output .= '</div>';
 
 							if ( $this->is_error( $key ) ) {
-								$output .= $this->field_error( $this->show_error( $key ) );
+								$output .= $this->field_error( $this->show_error( $key ), esc_attr( $key . $form_suffix ) );
 							} elseif ( $this->is_notice( $key ) ) {
 								$output .= $this->field_notice( $this->show_notice( $key ) );
 							}
@@ -2610,12 +2614,12 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					$field_name  = $key . $form_suffix;
 					$field_value = $this->field_value( $key, $default, $data );
 
-					$output .= '<input  ' . $disabled . '  class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" />
+					$output .= '<input  ' . $disabled . '  class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . ' />
 
 						</div>';
 
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_name ) );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -2656,12 +2660,12 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 						$disabled_weekdays = '[' . implode( ',', $data['disabled_weekdays'] ) . ']';
 					}
 
-					$output .= '<input ' . $disabled . '  class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" data-range="' . esc_attr( $data['range'] ) . '" data-years="' . esc_attr( $data['years'] ) . '" data-years_x="' . esc_attr( $data['years_x'] ) . '" data-disabled_weekdays="' . esc_attr( $disabled_weekdays ) . '" data-date_min="' . esc_attr( $data['date_min'] ) . '" data-date_max="' . esc_attr( $data['date_max'] ) . '" data-format="' . esc_attr( $data['js_format'] ) . '" data-value="' . esc_attr( $value ) . '" />
+					$output .= '<input ' . $disabled . '  class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" data-range="' . esc_attr( $data['range'] ) . '" data-years="' . esc_attr( $data['years'] ) . '" data-years_x="' . esc_attr( $data['years_x'] ) . '" data-disabled_weekdays="' . esc_attr( $disabled_weekdays ) . '" data-date_min="' . esc_attr( $data['date_min'] ) . '" data-date_max="' . esc_attr( $data['date_max'] ) . '" data-format="' . esc_attr( $data['js_format'] ) . '" data-value="' . esc_attr( $value ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . ' />
 
 						</div>';
 
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_name ) );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -2685,12 +2689,12 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					$field_name  = $key . $form_suffix;
 					$field_value = $this->field_value( $key, $default, $data );
 
-					$output .= '<input  ' . $disabled . '  class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '"  data-format="' . esc_attr( $data['js_format'] ) . '" data-intervals="' . esc_attr( $data['intervals'] ) . '" data-value="' . esc_attr( $field_value ) . '" />
+					$output .= '<input  ' . $disabled . '  class="' . esc_attr( $this->get_class( $key, $data ) ) . '" type="' . esc_attr( $input ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" placeholder="' . esc_attr( $placeholder ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '"  data-format="' . esc_attr( $data['js_format'] ) . '" data-intervals="' . esc_attr( $data['intervals'] ) . '" data-value="' . esc_attr( $field_value ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . ' />
 
 						</div>';
 
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_name ) );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -2798,7 +2802,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 								}
 							}
 						}
-						$output .= '<textarea  ' . $disabled . '  style="height: ' . esc_attr( $data['height'] ) . ';" class="' . esc_attr( $this->get_class( $key, $data ) ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_id ) . '" placeholder="' . esc_attr( $placeholder ) . '">' . esc_textarea( $textarea_field_value ) . '</textarea>';
+						$output .= '<textarea  ' . $disabled . '  style="height: ' . esc_attr( $data['height'] ) . ';" class="' . esc_attr( $this->get_class( $key, $data ) ) . '" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_id ) . '" placeholder="' . esc_attr( $placeholder ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $field_id) . '>' . esc_textarea( $textarea_field_value ) . '</textarea>';
 					}
 
 					$output .= '</div>';
@@ -2808,7 +2812,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					}
 
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_id ) );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -2825,11 +2829,11 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 					$output .= '<div class="um-field-area">';
 
-					$output .= '<div class="um-rating um-raty" id="' . esc_attr( $key ) . '" data-key="' . esc_attr( $key ) . '" data-number="' . esc_attr( $data['number'] ) . '" data-score="' . $this->field_value( $key, $default, $data ) . '"></div>';
+					$output .= '<div class="um-rating um-raty" id="' . esc_attr( $key ) . '" data-key="' . esc_attr( $key ) . '" data-number="' . esc_attr( $data['number'] ) . '" data-score="' . $this->field_value( $key, $default, $data ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $key) . '></div>';
 					$output .= '</div>';
 
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ), esc_attr( $key ) );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -2878,7 +2882,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 					$field_name = $key . $form_suffix;
 
-					$output .= '<input type="hidden" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" />';
+					$output .= '<input type="hidden" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $field_value ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . ' />';
 					if ( isset( $data['label'] ) ) {
 						$output .= $this->field_label( $data['label'], $key, $data );
 					}
@@ -2963,7 +2967,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					}
 					/* end */
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_name ) );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -2977,7 +2981,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					$field_name       = $key . $form_suffix;
 					$file_field_value = $this->field_value( $key, $default, $data );
 
-					$output .= '<input type="hidden" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $file_field_value ) . '" />';
+					$output .= '<input type="hidden" name="' . esc_attr( $field_name ) . '" id="' . esc_attr( $field_name ) . '" value="' . esc_attr( $file_field_value ) . '" ' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . ' />';
 					if ( isset( $data['label'] ) ) {
 						$output .= $this->field_label( $data['label'], $key, $data );
 					}
@@ -3088,7 +3092,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					}
 					/* end */
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_name ) );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -3307,7 +3311,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 					$field_value = '';
 
-					$output .= '<select data-default="' . esc_attr( $default ) . '" ' . $disabled . ' ' . $select_original_option_value . ' ' . $disabled_by_parent_option . '  name="' . esc_attr( $form_key ) . '" id="' . esc_attr( $field_id ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" class="' . esc_attr( $this->get_class( $key, $data, $class ) ) . '" style="width: 100%" data-placeholder="' . esc_attr( $placeholder ) . '" ' . $atts_ajax . '>';
+					$output .= '<select data-default="' . esc_attr( $default ) . '" ' . $disabled . ' ' . $select_original_option_value . ' ' . $disabled_by_parent_option . '  name="' . esc_attr( $form_key ) . '" id="' . esc_attr( $field_id ) . '" data-validate="' . esc_attr( $validate ) . '" data-key="' . esc_attr( $key ) . '" class="' . esc_attr( $this->get_class( $key, $data, $class ) ) . '" style="width: 100%" data-placeholder="' . esc_attr( $placeholder ) . '" ' . $atts_ajax . ' ' . $this->aria_valid_attributes($this->is_error( $key ), $field_name) . ' >';
 					$output .= '<option value=""></option>';
 
 					// add options
@@ -3352,7 +3356,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					$output .= '</div>';
 
 					if ( $this->is_error( $form_key ) ) {
-						$output .= $this->field_error( $this->show_error( $form_key ) );
+						$output .= $this->field_error( $this->show_error( $form_key ), esc_attr( $field_id ) );
 					} elseif ( $this->is_notice( $form_key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $form_key ) );
 					}
@@ -3508,7 +3512,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					$output .= '</div>';
 
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_id ) );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -3563,7 +3567,9 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					$options = apply_filters( "um_radio_field_options_{$key}", $options );
 					$options = $this->get_available_roles( $form_key, $options );
 
-					$output .= '<div ' . $this->get_atts( $key, $classes, $conditional, $data ) . '>';
+					$aria_id = $form_key . $form_suffix;
+
+					$output .= '<div ' . $this->get_atts( $key, $classes, $conditional, $data ) . $this->aria_valid_attributes($this->is_error( $key ), $aria_id) . ' >';
 
 					if ( isset( $data['label'] ) ) {
 						$output .= $this->field_label( $data['label'], $key, $data );
@@ -3634,7 +3640,10 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 							$option_value = $this->filter_field_non_utf8_value( $option_value );
 
-							$output .= '<input ' . $disabled . ' type="radio" name="' . ( ( 'role' === $form_key ) ? esc_attr( $form_key ) : esc_attr( $form_key ) . '[]' ) . '" value="' . esc_attr( $option_value ) . '" ';
+
+
+							//' id="' . esc_attr( $field_id ) .
+							$output .= '<input ' . $disabled . '" type="radio" name="' . ( ( 'role' === $form_key ) ? esc_attr( $form_key ) : esc_attr( $form_key ) . '[]' ) . '" value="' . esc_attr( $option_value ) . '" ';
 
 							if ( $this->is_radio_checked( $key, $option_value, $data ) ) {
 								$output             .= 'checked';
@@ -3664,7 +3673,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					$output .= '</div>';
 
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ), esc_attr( $field_id ) );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -3756,13 +3765,15 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 						$v          = $this->filter_field_non_utf8_value( $v );
 						$value_attr = ( ! empty( $v ) && is_string( $v ) ) ? wp_strip_all_tags( $v ) : $v;
 
-						$output .= '<input  ' . $disabled . ' type="checkbox" name="' . esc_attr( $key ) . '[]" value="' . esc_attr( $value_attr ) . '" ';
+						$field_id = $form_key . $form_suffix;
+
+						$output .= '<input  ' . $disabled . ' id="' . esc_attr( $field_id ) . 'type="checkbox" name="' . esc_attr( $key ) . '[]" value="' . esc_attr( $value_attr ) . '" ';
 
 						if ( $this->is_selected( $key, $v, $data ) ) {
 							$output .= 'checked';
 						}
 
-						$output .= ' />';
+						$output .= $this->aria_valid_attributes($this->is_error( $key ), $field_id) . ' />';
 
 						if ( ! empty( $disabled ) && $this->is_selected( $key, $v, $data ) ) {
 							$output .= $this->disabled_hidden_field( $key . '[]', $value_attr );
@@ -3804,7 +3815,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 					$output .= '</div>';
 
 					if ( $this->is_error( $key ) ) {
-						$output .= $this->field_error( $this->show_error( $key ) );
+						$output .= $this->field_error( $this->show_error( $key ),  );
 					} elseif ( $this->is_notice( $key ) ) {
 						$output .= $this->field_notice( $this->show_notice( $key ) );
 					}
@@ -4047,7 +4058,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 				UM()->form()->nonce = wp_create_nonce( 'um-profile-nonce' . UM()->user()->target_id );
 			}
 
-			$this->set_id = $this->global_args['form_id'];
+			$this->set_id = absint( $this->global_args['form_id'] );
 
 			$this->field_icons = ( isset( $this->global_args['icons'] ) ) ? $this->global_args['icons'] : 'label';
 
@@ -4548,7 +4559,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 			UM()->form()->form_suffix = '-' . $this->global_args['form_id'];
 
 			$this->set_mode = $mode;
-			$this->set_id = $this->global_args['form_id'];
+			$this->set_id   = absint( $this->global_args['form_id'] );
 
 			$this->field_icons = ( isset( $this->global_args['icons'] ) ) ? $this->global_args['icons'] : 'label';
 

--- a/includes/core/class-form.php
+++ b/includes/core/class-form.php
@@ -710,7 +710,7 @@ if ( ! class_exists( 'um\core\Form' ) ) {
 		public function beautify( $form ) {
 			if ( isset( $form['form_id'] ) ) {
 				$this->form_suffix = '-' . $form['form_id'];
-				$this->processing  = $form['form_id'];
+				$this->processing  = absint( $form['form_id'] );
 
 				foreach ( $form as $key => $value ) {
 					if ( strstr( $key, $this->form_suffix ) ) {

--- a/includes/core/class-password.php
+++ b/includes/core/class-password.php
@@ -170,7 +170,7 @@ if ( ! class_exists( 'um\core\Password' ) ) {
 				return '';
 			}
 
-			UM()->fields()->set_id = $args['form_id'];
+			UM()->fields()->set_id = absint( $args['form_id'] );
 
 			ob_start();
 

--- a/includes/core/class-shortcodes.php
+++ b/includes/core/class-shortcodes.php
@@ -805,6 +805,12 @@ if ( ! class_exists( 'um\core\Shortcodes' ) ) {
 				}
 			}
 
+			$content = apply_filters( 'um_force_shortcode_render', false, $args );
+			if ( false !== $content ) {
+				ob_get_clean();
+				return $content;
+			}
+
 			/**
 			 * Fires before loading form shortcode.
 			 *

--- a/includes/core/um-actions-profile.php
+++ b/includes/core/um-actions-profile.php
@@ -1287,7 +1287,7 @@ function um_profile_header( $args ) {
 						</span>
 						<?php
 						if ( UM()->fields()->is_error( $description_key ) ) {
-							echo UM()->fields()->field_error( UM()->fields()->show_error( $description_key ), true );
+							echo UM()->fields()->field_error( UM()->fields()->show_error( $description_key ), "um-meta-bio", true );
 						}
 						?>
 					</div>
@@ -1332,7 +1332,7 @@ function um_profile_header( $args ) {
 		<div class="um-clear"></div>
 
 		<?php if ( UM()->fields()->is_error( 'profile_photo' ) ) {
-			echo UM()->fields()->field_error( UM()->fields()->show_error( 'profile_photo' ), 'force_show' );
+			echo UM()->fields()->field_error( UM()->fields()->show_error( 'profile_photo' ), "profile_photo", 'force_show' );
 		}
 
 		/**


### PR DESCRIPTION
* Adding aria-errormessage and aria-valid tags to enhance 508 Compliance on UM forms
* Merging from development/2.6.11
* Minor fix in development/2.6.11 that caused error messages to not show up (class-form->processing was changed to an int [class-form.php 713], so === was failing)