### PR TITLE
Wrong fields in the login form displayed on the User page

### DIFF
--- a/includes/core/class-fields.php
+++ b/includes/core/class-fields.php
@@ -2205,7 +2205,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 			$autocomplete = array_key_exists( 'autocomplete', $data ) ? $data['autocomplete'] : 'off';
 
-			$classes = '';
+			$classes = array();
 			if ( array_key_exists( 'classes', $data ) ) {
 				$classes = explode( ' ', $data['classes'] );
 			}
@@ -4053,7 +4053,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 			// start output here
 			if ( ! empty( $this->global_args['custom_fields'] ) && is_array( $this->global_args['custom_fields'] ) ) {
-				$this->get_fields = $this->global_args['custom_fields'];
+				$this->get_fields = apply_filters( 'um_get_form_fields', $this->global_args['custom_fields'] );
 			} else {
 				$this->get_fields = $this->get_fields();
 			}
@@ -4214,11 +4214,11 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 
 			// Get whole field data.
 			if ( is_array( $data ) ) {
-				$data = $this->get_field( $key );
+				$data = wp_parse_args( $data, $this->get_field( $key ) );
 			}
 
-			//hide if empty type
-			if ( ! array_key_exists( 'type', $data ) || empty( $data['type'] ) ) {
+			// hide if empty type.
+			if ( empty( $data ) || ! array_key_exists( 'type', $data ) || empty( $data['type'] ) ) {
 				return '';
 			}
 			$type = $data['type'];
@@ -4257,7 +4257,7 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 				return '';
 			}
 
-			$classes = '';
+			$classes = array();
 			if ( ! empty( $data['classes'] ) ) {
 				$classes = explode( ' ', $data['classes'] );
 			}
@@ -4557,7 +4557,11 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 			$this->field_icons = ( isset( $this->global_args['icons'] ) ) ? $this->global_args['icons'] : 'label';
 
 			// start output here
-			$this->get_fields = $this->get_fields();
+			if ( ! empty( $this->global_args['custom_fields'] ) && is_array( $this->global_args['custom_fields'] ) ) {
+				$this->get_fields = apply_filters( 'um_get_form_fields', $this->global_args['custom_fields'] );
+			} else {
+				$this->get_fields = $this->get_fields();
+			}
 
 			if ( UM()->options()->get( 'profile_empty_text' ) ) {
 

--- a/includes/core/class-fields.php
+++ b/includes/core/class-fields.php
@@ -4052,7 +4052,11 @@ if ( ! class_exists( 'um\core\Fields' ) ) {
 			$this->field_icons = ( isset( $this->global_args['icons'] ) ) ? $this->global_args['icons'] : 'label';
 
 			// start output here
-			$this->get_fields = $this->get_fields();
+			if ( ! empty( $this->global_args['custom_fields'] ) && is_array( $this->global_args['custom_fields'] ) ) {
+				$this->get_fields = $this->global_args['custom_fields'];
+			} else {
+				$this->get_fields = $this->get_fields();
+			}
 
 			if ( ! empty( $this->get_fields ) ) {
 


### PR DESCRIPTION
Fixed login form fields. 
Get fields from the form arguments if the `custom_fields` key is not empty. Use the default method to get fields otherwise. 