### PR TITLE
Redirection from default registration to UM registration

### DIFF
--- a/includes/core/um-actions-register.php
+++ b/includes/core/um-actions-register.php
@@ -742,12 +742,12 @@ function um_registration_set_profile_full_name( $user_id, $args ) {
 add_action( 'um_registration_set_extra_data', 'um_registration_set_profile_full_name', 10, 2 );
 
 /**
- *  Redirect from default registration to UM registration page
+ * Redirect from default registration to UM registration page
  */
 function um_form_register_redirect() {
-	$page_id       = UM()->options()->get( UM()->options()->get_core_page_id( 'register' ) );
-	$register_post = get_post( $page_id );
-	if ( ! empty( $register_post ) ) {
+	$page_id = UM()->options()->get( UM()->options()->get_core_page_id( 'register' ) );
+	// Do not redirect if the registration page is not published.
+	if ( ! empty( $page_id ) && 'publish' === get_post_status( $page_id ) ) {
 		// Not `um_safe_redirect()` because predefined register page is situated on the same host.
 		wp_safe_redirect( get_permalink( $page_id ) );
 		exit();


### PR DESCRIPTION
Do not redirect from the default WordPress registration page to the UM registration page if the page is not published.