### PR TITLE
Builder image class

### DIFF
--- a/includes/admin/core/class-admin-metabox.php
+++ b/includes/admin/core/class-admin-metabox.php
@@ -93,7 +93,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 		 */
 		function hide_metabox_restrict_content_shop( $hide ) {
 			if ( function_exists( 'wc_get_page_id' ) && ! empty( $_GET['post'] ) &&
-			     absint( $_GET['post'] ) == wc_get_page_id( 'shop' ) ) {
+				 absint( $_GET['post'] ) == wc_get_page_id( 'shop' ) ) {
 				return true;
 			}
 
@@ -220,7 +220,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 		public function save_metabox_custom( $post_id, $post ) {
 			// validate nonce
 			if ( ! isset( $_POST['um_admin_save_metabox_custom_nonce'] ) ||
-			     ! wp_verify_nonce( $_POST['um_admin_save_metabox_custom_nonce'], basename( __FILE__ ) ) ) {
+				 ! wp_verify_nonce( $_POST['um_admin_save_metabox_custom_nonce'], basename( __FILE__ ) ) ) {
 				return;
 			}
 
@@ -324,7 +324,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 		function save_metabox_restrict_content( $post_id, $post ) {
 			// validate nonce
 			if ( ! isset( $_POST['um_admin_save_metabox_restrict_content_nonce'] ) ||
-			     ! wp_verify_nonce( $_POST['um_admin_save_metabox_restrict_content_nonce'], basename( __FILE__ ) ) ) {
+				 ! wp_verify_nonce( $_POST['um_admin_save_metabox_restrict_content_nonce'], basename( __FILE__ ) ) ) {
 				return;
 			}
 
@@ -351,7 +351,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 		function save_attachment_metabox_restrict_content( $post_id ) {
 			// validate nonce
 			if ( ! isset( $_POST['um_admin_save_metabox_restrict_content_nonce'] )
-			     || ! wp_verify_nonce( $_POST['um_admin_save_metabox_restrict_content_nonce'], basename( __FILE__ ) ) ) {
+				 || ! wp_verify_nonce( $_POST['um_admin_save_metabox_restrict_content_nonce'], basename( __FILE__ ) ) ) {
 				return;
 			}
 
@@ -1166,7 +1166,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 
 			// validate nonce
 			if ( ! isset( $_POST['um_admin_save_metabox_form_nonce'] ) ||
-			     ! wp_verify_nonce( $_POST['um_admin_save_metabox_form_nonce'], basename( __FILE__ ) ) ) {
+				 ! wp_verify_nonce( $_POST['um_admin_save_metabox_form_nonce'], basename( __FILE__ ) ) ) {
 				return;
 			}
 
@@ -1254,7 +1254,6 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 			}
 		}
 
-
 		/**
 		 * Show field input for edit at modal field
 		 *
@@ -1262,7 +1261,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 		 * @param null $form_id
 		 * @param array $field_args
 		 */
-		function field_input( $attribute, $form_id = null, $field_args = array() ) {
+		public function field_input( $attribute, $form_id = null, $field_args = array() ) {
 
 			if ( $this->in_edit == true ) { // we're editing a field
 				$real_attr = substr( $attribute, 1 );
@@ -1270,9 +1269,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 			}
 
 			switch ( $attribute ) {
-
 				default:
-
 					/**
 					 * UM hook
 					 *
@@ -1299,7 +1296,8 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 				case '_visibility':
 					?>
 
-					<p><label for="_visibility"><?php _e( 'Visibility', 'ultimate-member' ) ?> <?php UM()->tooltip( __( 'Select where this field should appear. This option should only be changed on the profile form and allows you to show a field in one mode only (edit or view) or in both modes.','ultimate-member' ) ); ?></label>
+					<p>
+						<label for="_visibility"><?php esc_html_e( 'Visibility', 'ultimate-member' ); ?> <?php UM()->tooltip( __( 'Select where this field should appear. This option should only be changed on the profile form and allows you to show a field in one mode only (edit or view) or in both modes.','ultimate-member' ) ); ?></label>
 						<select name="_visibility" id="_visibility" style="width: 100%">
 							<option value="all" <?php selected( 'all', $this->edit_mode_value ); ?>><?php _e( 'View everywhere', 'ultimate-member' ) ?></option>
 							<option value="edit" <?php selected( 'edit', $this->edit_mode_value ); ?>><?php _e( 'Edit mode only', 'ultimate-member' ) ?></option>
@@ -1315,104 +1313,91 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 				case '_conditional_action2':
 				case '_conditional_action3':
 				case '_conditional_action4':
-				?>
+					?>
 
-				<p>
-					<select name="<?php echo esc_attr( $attribute ); ?>" id="<?php echo esc_attr( $attribute ); ?>" style="width: 90px">
+					<p>
+						<select name="<?php echo esc_attr( $attribute ); ?>" id="<?php echo esc_attr( $attribute ); ?>" style="width: 90px">
+							<option></option>
+							<?php
+							$actions = array( 'show', 'hide' );
+							foreach ( $actions as $action ) {
+								?>
+								<option value="<?php echo esc_attr( $action ); ?>" <?php selected( $action, $this->edit_mode_value ); ?>><?php echo esc_html( $action ); ?></option>
+								<?php
+							}
+							?>
+						</select>
 
-						<option></option>
+						&nbsp;&nbsp;<?php esc_html_e( 'If', 'ultimate-member' ); ?>
+					</p>
 
-						<?php $actions = array( 'show', 'hide' );
-						foreach ( $actions as $action ) { ?>
-
-							<option value="<?php echo esc_attr( $action ); ?>" <?php selected( $action, $this->edit_mode_value ); ?>><?php echo $action; ?></option>
-
-						<?php } ?>
-
-					</select>
-
-					&nbsp;&nbsp;<?php _e( 'If' ); ?>
-				</p>
-
-				<?php
-				break;
+					<?php
+					break;
 
 				case '_conditional_field':
 				case '_conditional_field1':
 				case '_conditional_field2':
 				case '_conditional_field3':
 				case '_conditional_field4':
-				?>
-
-				<p>
-					<select name="<?php echo esc_attr( $attribute ); ?>" id="<?php echo esc_attr( $attribute ); ?>" style="width: 150px">
-
-						<option></option>
-
-						<?php $fields = UM()->query()->get_attr( 'custom_fields', $form_id );
-
-						foreach ( $fields as $key => $array ) {
-							if ( isset( $array['title'] ) &&
-							     ( ! isset( $this->edit_array['metakey'] ) || $key != $this->edit_array['metakey'] ) ) { ?>
-
-								<option value="<?php echo esc_attr( $key ) ?>" <?php selected( $key, $this->edit_mode_value ) ?>><?php echo $array['title'] ?></option>
-
-							<?php }
-						} ?>
-
-					</select>
-				</p>
-
-				<?php
-				break;
+					?>
+					<p>
+						<select name="<?php echo esc_attr( $attribute ); ?>" id="<?php echo esc_attr( $attribute ); ?>" style="width: 150px">
+							<option></option>
+							<?php
+							$fields = UM()->query()->get_attr( 'custom_fields', $form_id );
+							foreach ( $fields as $key => $array ) {
+								if ( isset( $array['title'] ) &&
+									 ( ! isset( $this->edit_array['metakey'] ) || $key != $this->edit_array['metakey'] ) ) {
+									?>
+									<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $key, $this->edit_mode_value ); ?>><?php echo esc_html( $array['title'] ); ?></option>
+									<?php
+								}
+							}
+							?>
+						</select>
+					</p>
+					<?php
+					break;
 
 				case '_conditional_operator':
 				case '_conditional_operator1':
 				case '_conditional_operator2':
 				case '_conditional_operator3':
 				case '_conditional_operator4':
-				?>
-
-				<p>
-					<select name="<?php echo esc_attr( $attribute ); ?>" id="<?php echo esc_attr( $attribute ); ?>" style="width: 150px">
-
-						<option></option>
-
-						<?php $operators = array(
-							'empty',
-							'not empty',
-							'equals to',
-							'not equals',
-							'greater than',
-							'less than',
-							'contains'
-						);
-
-						foreach ( $operators as $operator ) { ?>
-
-							<option value="<?php echo esc_attr( $operator ); ?>" <?php selected( $operator, $this->edit_mode_value ); ?>><?php echo $operator; ?></option>
-
-						<?php } ?>
-
-					</select>
-				</p>
-
-				<?php
-				break;
+					$operators = array(
+						'empty',
+						'not empty',
+						'equals to',
+						'not equals',
+						'greater than',
+						'less than',
+						'contains',
+					);
+					?>
+					<p>
+						<select name="<?php echo esc_attr( $attribute ); ?>" id="<?php echo esc_attr( $attribute ); ?>" style="width: 150px">
+							<option></option>
+							<?php foreach ( $operators as $operator ) { ?>
+								<option value="<?php echo esc_attr( $operator ); ?>" <?php selected( $operator, $this->edit_mode_value ); ?>><?php echo esc_html( $operator ); ?></option>
+							<?php } ?>
+						</select>
+					</p>
+					<?php
+					break;
 
 				case '_conditional_value':
 				case '_conditional_value1':
 				case '_conditional_value2':
 				case '_conditional_value3':
 				case '_conditional_value4':
-				?>
+					?>
 
-				<p>
-					<input type="text" name="<?php echo esc_attr( $attribute ); ?>" id="<?php echo esc_attr( $attribute ); ?>" value="<?php echo isset( $this->edit_mode_value ) ? $this->edit_mode_value : ''; ?>" placeholder="<?php esc_attr_e( 'Value', 'ultimate-member' ); ?>" style="width: 150px!important;position: relative;top: -1px;" />
-				</p>
+					<p>
+						<input type="text" name="<?php echo esc_attr( $attribute ); ?>" id="<?php echo esc_attr( $attribute ); ?>" value="<?php echo isset( $this->edit_mode_value ) ? esc_attr( $this->edit_mode_value ) : ''; ?>" placeholder="<?php esc_attr_e( 'Value', 'ultimate-member' ); ?>" style="width: 150px!important;position: relative;top: -1px;" />
+					</p>
 
-				<?php
-				break;
+					<?php
+					break;
 
 				case '_validate':
 					?>
@@ -1470,62 +1455,49 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 					break;
 
 				case '_icon':
-
-					if ( $this->set_field_type == 'row' ) {
+					if ( 'row' === $this->set_field_type ) {
 						$back = 'UM_edit_row';
-
 						?>
+						<p class="_heading_text"><label for="_icon"><?php esc_html_e( 'Icon', 'ultimate-member' ); ?> <?php UM()->tooltip( __( 'Select an icon to appear in the field. Leave blank if you do not want an icon to show in the field.', 'ultimate-member' ) ); ?></label>
+							<a href="javascript:void(0);" class="button" data-modal="UM_fonticons" data-modal-size="normal" data-dynamic-content="um_admin_fonticon_selector" data-arg1="" data-arg2="" data-back="<?php echo esc_attr( $back ); ?>"><?php esc_html_e( 'Choose Icon', 'ultimate-member' ); ?></a>
 
-						<p class="_heading_text"><label for="_icon"><?php _e( 'Icon', 'ultimate-member' ) ?> <?php UM()->tooltip( __( 'Select an icon to appear in the field. Leave blank if you do not want an icon to show in the field.', 'ultimate-member' ) ); ?></label>
+							<span class="um-admin-icon-value"><?php if ( ! empty( $this->edit_mode_value ) ) { ?><i class="<?php echo esc_attr( $this->edit_mode_value ); ?>"></i><?php } else { ?><?php esc_html_e( 'No Icon', 'ultimate-member' ); ?><?php } ?></span>
 
-							<a href="javascript:void(0);" class="button" data-modal="UM_fonticons" data-modal-size="normal" data-dynamic-content="um_admin_fonticon_selector" data-arg1="" data-arg2="" data-back="<?php echo esc_attr( $back ); ?>"><?php _e( 'Choose Icon', 'ultimate-member' ) ?></a>
+							<input type="hidden" name="_icon" id="_icon" value="<?php echo ! empty( $this->edit_mode_value ) ? esc_attr( $this->edit_mode_value ) : ''; ?>" />
 
-							<span class="um-admin-icon-value"><?php if ( $this->edit_mode_value ) { ?><i class="<?php echo $this->edit_mode_value; ?>"></i><?php } else { ?><?php _e( 'No Icon', 'ultimate-member' ) ?><?php } ?></span>
-
-							<input type="hidden" name="_icon" id="_icon" value="<?php echo (isset( $this->edit_mode_value ) ) ? $this->edit_mode_value : ''; ?>" />
-
-							<?php if ( $this->edit_mode_value ) { ?>
+							<?php if ( ! empty( $this->edit_mode_value ) ) { ?>
 								<span class="um-admin-icon-clear show"><i class="um-icon-android-cancel"></i></span>
 							<?php } else { ?>
 								<span class="um-admin-icon-clear"><i class="um-icon-android-cancel"></i></span>
 							<?php } ?>
-
 						</p>
-
-					<?php } else {
-
+						<?php
+					} else {
 						if ( $this->in_edit ) {
 							$back = 'UM_edit_field';
 						} else {
 							$back = 'UM_add_field';
 						}
-
 						?>
-
 						<div class="um-admin-tri">
+							<p>
+								<label for="_icon"><?php esc_html_e( 'Icon', 'ultimate-member' ); ?> <?php UM()->tooltip( __( 'Select an icon to appear in the field. Leave blank if you do not want an icon to show in the field.', 'ultimate-member' ) ); ?></label>
 
-							<p><label for="_icon"><?php _e( 'Icon', 'ultimate-member' ) ?> <?php UM()->tooltip( __( 'Select an icon to appear in the field. Leave blank if you do not want an icon to show in the field.', 'ultimate-member' ) ); ?></label>
+								<a href="javascript:void(0);" class="button" data-modal="UM_fonticons" data-modal-size="normal" data-dynamic-content="um_admin_fonticon_selector" data-arg1="" data-arg2="" data-back="<?php echo esc_attr( $back ); ?>"><?php esc_html_e( 'Choose Icon', 'ultimate-member' ); ?></a>
 
-								<a href="javascript:void(0);" class="button" data-modal="UM_fonticons" data-modal-size="normal" data-dynamic-content="um_admin_fonticon_selector" data-arg1="" data-arg2="" data-back="<?php echo esc_attr( $back ); ?>"><?php _e( 'Choose Icon', 'ultimate-member' ) ?></a>
+								<span class="um-admin-icon-value"><?php if ( ! empty( $this->edit_mode_value ) ) { ?><i class="<?php echo esc_attr( $this->edit_mode_value ); ?>"></i><?php } else { ?><?php esc_html_e( 'No Icon', 'ultimate-member' ) ?><?php } ?></span>
 
-								<span class="um-admin-icon-value"><?php if ( $this->edit_mode_value ) { ?><i class="<?php echo $this->edit_mode_value; ?>"></i><?php } else { ?><?php _e( 'No Icon', 'ultimate-member' ) ?><?php } ?></span>
+								<input type="hidden" name="_icon" id="_icon" value="<?php echo ! empty( $this->edit_mode_value ) ? esc_attr( $this->edit_mode_value ) : ''; ?>" />
 
-								<input type="hidden" name="_icon" id="_icon" value="<?php echo (isset( $this->edit_mode_value ) ) ? $this->edit_mode_value : ''; ?>" />
-
-								<?php if ( $this->edit_mode_value ) { ?>
+								<?php if ( ! empty( $this->edit_mode_value ) ) { ?>
 									<span class="um-admin-icon-clear show"><i class="um-icon-android-cancel"></i></span>
 								<?php } else { ?>
 									<span class="um-admin-icon-clear"><i class="um-icon-android-cancel"></i></span>
 								<?php } ?>
-
 							</p>
-
 						</div>
-
 						<?php
-
 					}
-
 					break;
 
 				case '_css_class':
@@ -2445,11 +2417,10 @@ if ( ! class_exists( 'um\admin\core\Admin_Metabox' ) ) {
 
 					<?php
 					break;
-
-
 			}
 
+			// Flush class variable.
+			$this->edit_mode_value = null;
 		}
-
 	}
 }


### PR DESCRIPTION
Without flushing UM()->metabox()->edit_mode_value variable it is possible to create fields with a wrong field icon and conditional logic values.

Ref screenshot:
<img width="913" alt="Add-New-Form-‹-—-WordPress-2023-09-07-18-28-24" src="https://github.com/ultimatemember/ultimatemember/assets/26598684/2c40bf2f-3134-4483-9b77-6669ae0a519d">
