### PR TITLE
Avoid regenerating hash for profile URL on profile update

### DIFF
--- a/includes/core/class-user.php
+++ b/includes/core/class-user.php
@@ -790,7 +790,11 @@ if ( ! class_exists( 'um\core\User' ) ) {
 			}
 
 			if ( 'hash' === $permalink_base ) {
-				$user_in_url = $this->generate_user_hash( $user_id );
+				if ( empty( $current_profile_slug ) ) {
+					$user_in_url = $this->generate_user_hash( $user_id );
+				} else {
+					$user_in_url = $current_profile_slug;
+				}
 			}
 
 			if ( 'custom_meta' === $permalink_base ) {


### PR DESCRIPTION
With the new permalink base `hash` function, it appears the hash keeps regenerating on each profile update. Is this intentional? I checked Upwork, and it doesn't regenerate the profile URL as it is a bad user experience and SEO.

While also debugging the hash issue, I've also observed that we have duplicate `generate_profile_slug` function calls on each update:
https://github.com/ultimatemember/ultimatemember/blob/master/includes/core/class-user.php#L922
https://github.com/ultimatemember/ultimatemember/blob/master/includes/core/um-actions-save-profile.php#L104