### PR TITLE
Fix stripslashes

### DIFF
--- a/includes/core/class-roles-capabilities.php
+++ b/includes/core/class-roles-capabilities.php
@@ -655,7 +655,7 @@ if ( ! class_exists( 'um\core\Roles_Capabilities' ) ) {
 		 *
 		 * @return array
 		 */
-		function get_roles( $add_default = false, $exclude = null ) {
+		public function get_roles( $add_default = false, $exclude = null ) {
 			global $wp_roles;
 
 			if ( empty( $wp_roles ) ) {
@@ -670,11 +670,19 @@ if ( ! class_exists( 'um\core\Roles_Capabilities' ) ) {
 
 			if ( $exclude ) {
 				foreach ( $exclude as $role ) {
-					unset ( $roles[ $role ] );
+					unset( $roles[ $role ] );
 				}
 			}
 
-			$roles = array_map( 'stripslashes', $roles );
+			$roles = array_map(
+				function( $role ) {
+					if ( is_string( $role ) ) {
+						return stripslashes( $role );
+					}
+					return $role;
+				},
+				$roles
+			);
 
 			return $roles;
 		}


### PR DESCRIPTION
- fix an error in PHP 8:
`Deprecated: stripslashes(): Passing null to parameter #1 ($string) of type string is deprecated in /xxxx/wp-content/plugins/ultimate-member/includes/core/class-roles-capabilities.php on line 677`