### PR TITLE
Field icon visibility

### DIFF
--- a/assets/css/um-styles.css
+++ b/assets/css/um-styles.css
@@ -456,6 +456,7 @@ p.um-notice.warning a {
 	width: 44px;
 	font-size: 22px;
 	line-height: 1.7em;
+	z-index: 1;
 }
 
 .um-form input[type="text"],


### PR DESCRIPTION
- The icon for the password field is not showing after enabling the option "Show/hide password button" (Settings - General -Users).