### PR TITLE
Fix date and time to filter suspicious accounts + minor fixes to the timestamp in GMT

### DIFF
--- a/includes/admin/class-secure.php
+++ b/includes/admin/class-secure.php
@@ -79,13 +79,16 @@ if ( ! class_exists( 'um\admin\Secure' ) ) {
 				$date_to   = isset( $_GET['um_secure_date_to'] ) ? $_GET['um_secure_date_to'] : null;
 				// phpcs:enable WordPress.Security.NonceVerification
 				if ( $date_from ) {
+
 					$date_query_attr = array(
-						'after'     => human_time_diff( $date_from, strtotime( current_time( 'mysql' ) ) ) . ' ago',
-						'inclusive' => true,
+						'after'  => wp_date( 'F j, Y', strtotime( '-1 day', $date_from ) ),
+						'before' => wp_date( 'F j, Y', strtotime( '+1 day', $date_from ) ),
 					);
+
 					if ( $date_to ) {
-						$date_query_attr['before'] = human_time_diff( $date_to, strtotime( current_time( 'mysql' ) ) ) . ' ago';
+						$date_query_attr['before'] = wp_date( 'F j, Y', strtotime( '+1 day', $date_to ) );
 					}
+
 					$query->set( 'date_query', $date_query_attr );
 				}
 			}
@@ -215,7 +218,7 @@ if ( ! class_exists( 'um\admin\Secure' ) ) {
 			$scan_status       = get_option( 'um_secure_scan_status' );
 			$last_scanned_time = get_option( 'um_secure_last_time_scanned' );
 			if ( ! empty( $last_scanned_time ) ) {
-				$scanner_content .= human_time_diff( strtotime( $last_scanned_time ), strtotime( current_time( 'mysql' ) ) ) . ' ' . esc_html__( 'ago', 'ultimate-member' );
+				$scanner_content .= human_time_diff( $last_scanned_time, current_datetime()->format( 'U' ) ) . ' ' . esc_html__( 'ago', 'ultimate-member' );
 				if ( 'started' === $scan_status ) {
 					$scanner_content .= ' - ' . esc_html__( 'Not Completed.', 'ultimate-member' );
 				}
@@ -338,7 +341,7 @@ if ( ! class_exists( 'um\admin\Secure' ) ) {
 					$restore_account_url = admin_url( 'users.php?user_id=' . $user_id . '&um_secure_restore_account=1&_wpnonce=' . $nonce );
 					$action              = ' &#183; <a href=" ' . esc_attr( $restore_account_url ) . ' " onclick=\'return confirm("' . esc_js( __( 'Are you sure that you want to restore this account after getting flagged for suspicious activity?', 'ultimate-member' ) ) . '");\'><small>' . esc_html__( 'Restore Account', 'ultimate-member' ) . '</small></a>';
 					if ( ! empty( $datetime ) ) {
-						$val .= '<div><small>' . human_time_diff( strtotime( $datetime ), strtotime( current_time( 'mysql' ) ) ) . ' ' . __( 'ago', 'ultimate-member' ) . '</small>' . $action . '</div>';
+						$val .= '<div><small>' . human_time_diff( $datetime, current_datetime()->format( 'U' ) ) . ' ' . __( 'ago', 'ultimate-member' ) . '</small>' . $action . '</div>';
 					}
 				}
 				um_reset_user();

--- a/includes/ajax/class-secure.php
+++ b/includes/ajax/class-secure.php
@@ -39,7 +39,7 @@ class Secure {
 		if ( empty( $last_scanned_capability ) ) {
 			delete_option( 'um_secure_scanned_details' );
 			update_option( 'um_secure_scan_status', 'started' );
-			update_option( 'um_secure_last_time_scanned', current_time( 'mysql' ) );
+			update_option( 'um_secure_last_time_scanned', current_datetime()->format( 'U' ) );
 		}
 
 		$scan_details = get_option( 'um_secure_scanned_details', array() );
@@ -206,6 +206,7 @@ class Secure {
 					$sessions_manager = WP_Session_Tokens::get_instance( $user->ID );
 					// Remove all the session data for all users.
 					$sessions_manager->destroy_all();
+
 				}
 			}
 
@@ -219,8 +220,8 @@ class Secure {
 					'number'     => -1,
 					'exclude'    => $arr_suspected_accounts,
 					'date_query' => array(
-						'after'  => gmdate( 'F d, Y', strtotime( '-1 day', $oldest_date ) ),
-						'before' => gmdate( 'F d, Y', strtotime( '+1 day', $newest_date ) ),
+						'after'  => wp_date( 'F d, Y', strtotime( '-1 day', $oldest_date ) ),
+						'before' => wp_date( 'F d, Y', strtotime( '+1 day', $newest_date ) ),
 					),
 				)
 			);

--- a/includes/common/class-secure.php
+++ b/includes/common/class-secure.php
@@ -235,7 +235,7 @@ if ( ! class_exists( 'um\common\Secure' ) ) {
 			}
 			um_reset_user();
 			update_user_meta( $user->ID, 'um_user_blocked', 'suspicious_activity' );
-			update_user_meta( $user->ID, 'um_user_blocked__timestamp', current_time( 'mysql' ) );
+			update_user_meta( $user->ID, 'um_user_blocked__timestamp', current_datetime()->format( 'U' ) );
 			UM()->user()->remove_cache( $user->ID );
 		}
 


### PR DESCRIPTION
There's an issue with the security scanner. It doesn't filter all suspicious accounts and timestamps are incorrectly saved that caused invalid datetime differences.