### PR TITLE
YouTube Video field does not support all YouTube links

### DIFF
--- a/includes/core/um-actions-form.php
+++ b/includes/core/um-actions-form.php
@@ -792,7 +792,7 @@ function um_submit_form_errors_hook_( $submitted_data, $form_data ) {
 				break;
 
 			case 'youtube_video':
-				if ( ! UM()->validation()->is_url( $submitted_data[ $key ], 'youtube.com/watch?v=' ) && ! UM()->validation()->is_url( $submitted_data[ $key ], 'youtu.be' ) && ! UM()->validation()->is_url( $submitted_data[ $key ], 'youtube.com/shorts/' ) ) {
+				if ( ! UM()->validation()->is_url( $submitted_data[ $key ] ) || false === um_youtube_id_from_url( $submitted_data[ $key ] ) ) {
 					// translators: %s: label.
 					UM()->form()->add_error( $key, sprintf( __( 'Please enter a valid %s URL', 'ultimate-member' ), $array['label'] ) );
 				}

--- a/includes/core/um-filters-fields.php
+++ b/includes/core/um-filters-fields.php
@@ -94,10 +94,11 @@ function um_profile_field_filter_hook__youtube_video( $value, $data ) {
 		return '';
 	}
 	$value = ( strstr( $value, 'http' ) || strstr( $value, '://' ) ) ? um_youtube_id_from_url( $value ) : $value;
-	$value = '<div class="um-youtube">
-					<iframe width="600" height="450" src="https://www.youtube.com/embed/' . $value . '" frameborder="0" allowfullscreen></iframe>
-					</div>';
-
+	if ( false !== $value ) {
+		$value = '<div class="um-youtube">'
+			. '<iframe width="600" height="450" src="https://www.youtube.com/embed/' . $value . '" frameborder="0" allowfullscreen></iframe>'
+			. '</div>';
+	}
 	return $value;
 }
 add_filter( 'um_profile_field_filter_hook__youtube_video', 'um_profile_field_filter_hook__youtube_video', 99, 2 );

--- a/includes/um-short-functions.php
+++ b/includes/um-short-functions.php
@@ -1918,20 +1918,24 @@ function um_youtube_id_from_url( $url ) {
 	$url = preg_replace( '/\?si=.*/', '', $url ); // referral attribute.
 
 	$pattern =
-		'%^# Match any youtube URL
-		(?:https?://)?  # Optional scheme. Either http or https
-		(?:www\.)?      # Optional www subdomain
-		(?:             # Group host alternatives
-		  youtu\.be/    # Either youtu.be,
-		| youtube\.com  # or youtube.com
-		  (?:           # Group path alternatives
-			/embed/     # Either /embed/
-		  | /v/         # or /v/
-		  | /watch\?v=  # or /watch\?v=
-		  | /shorts/    # or /shorts/ for short videos
-		  )             # End path alternatives.
-		)               # End host alternatives.
-		([\w-]{10,12})  # Allow 10-12 for 11 char youtube id.
+		'%^            # Match any youtube URL
+		(?:https?://)? # Optional scheme. Either http or https
+		(?:www\.)?     # Optional www subdomain
+		(?:            # Group host alternatives
+		  youtu\.be/   # Either youtu.be,
+		| youtube\.com # or youtube.com
+		  (?:          # Group path alternatives
+			/embed/      # Either /embed/
+		  | /v/        # or /v/
+		  | /watch\?v= # or /watch\?v=
+		  | /shorts/   # or /shorts/ for short videos
+		  )            # End path alternatives.
+		)              # End host alternatives.
+		([\w-]{10,12}) # Allow 10-12 for 11 char youtube id.
+		(?:            # Additional parameters
+		  (?:\?|\&)
+		  \w+=[^&$]+
+		)*
 		$%x';
 
 	$result = preg_match( $pattern, $url, $matches );

--- a/includes/um-short-functions.php
+++ b/includes/um-short-functions.php
@@ -1920,7 +1920,14 @@ function um_youtube_id_from_url( $url ) {
 	$pattern =
 		'%^            # Match any youtube URL
 		(?:https?://)? # Optional scheme. Either http or https
-		(?:www\.)?     # Optional www subdomain
+		(?:                 # Optional subdomain, for example m or www.
+			[a-z0-9]          # Subdomain begins with alpha-num.
+			(?:               # Optionally more than one char.
+				[a-z0-9-]{0,61} # Middle part may have dashes.
+				[a-z0-9]        # Starts and ends with alpha-num.
+			)?                # Subdomain length from 1 to 63.
+			\.                # Required dot separates subdomains.
+		)?                  # Subdomain is optional.
 		(?:            # Group host alternatives
 		  youtu\.be/   # Either youtu.be,
 		| youtube\.com # or youtube.com


### PR DESCRIPTION
The YouTube Video field will support YouTube links with subdomain, like _m.youtube.com_ or _music.youtube.com_.

The YouTube Video field will support YouTube links with additional parameters `list`, `index`, `pp`, etc.