### PR TITLE
Menu broken with 2.8.0 update (CU-86cu48dm7)

### DIFF
--- a/includes/core/um-filters-navmenu.php
+++ b/includes/core/um-filters-navmenu.php
@@ -72,9 +72,9 @@ if ( ! is_admin() ) {
 			$visible = true;
 
 			// Hide any item that is the child of a hidden item.
-			if ( isset( $item->menu_item_parent ) && in_array( $item->menu_item_parent, $hide_children_of, true ) ) {
+			if ( isset( $item->menu_item_parent ) && in_array( absint( $item->menu_item_parent ), $hide_children_of, true ) ) {
 				$visible            = false;
-				$hide_children_of[] = $item->ID; // for nested menus
+				$hide_children_of[] = absint( $item->ID ); // for nested menus
 			}
 
 			if ( isset( $mode ) && $visible ) {
@@ -118,7 +118,7 @@ if ( ! is_admin() ) {
 
 			// unset non-visible item
 			if ( ! $visible ) {
-				$hide_children_of[] = $item->ID; // store ID of item
+				$hide_children_of[] = absint( $item->ID ); // store ID of item
 			} else {
 				$filtered_items[] = $item;
 			}


### PR DESCRIPTION
Fixed the visibility of sub-items of hidden menu items.

Issue reported in the thread [Menu broken with 2.8.0 update](https://wordpress.org/support/topic/menu-broken-with-2-8-0-update/)