### PR TITLE
Fix error notice when generating predefined pages via extensions

### DIFF
--- a/includes/core/class-setup.php
+++ b/includes/core/class-setup.php
@@ -206,7 +206,7 @@ KEY meta_value_indx (um_value(191))
 					$content = '[ultimatemember_password]';
 				} elseif ( 'user' === $slug ) {
 					$content = '[ultimatemember form_id="' . $setup_shortcodes['profile'] . '"]';
-				} else {
+				} elseif ( ! empty( $setup_shortcodes[ $slug ] ) ) {
 					$content = '[ultimatemember form_id="' . $setup_shortcodes[ $slug ] . '"]';
 				}
 


### PR DESCRIPTION
When you register a predefined page in the extension,  it throws an error notice on "Create Pages":

```
[15-Dec-2023 15:35:11 UTC] PHP Warning:  Undefined array key "payment-successful" in /var/www/html/wp-content/plugins/ultimate-member/includes/core/class-setup.php on line 210
[15-Dec-2023 15:35:11 UTC] PHP Warning:  Undefined array key "payment-cancelled" in /var/www/html/wp-content/plugins/ultimate-member/includes/core/class-setup.php on line 210
[15-Dec-2023 15:35:11 UTC] PHP Warning:  Undefined array key "already-subscribed" in /var/www/html/wp-content/plugins/ultimate-member/includes/core/class-setup.php on line 210
[15-Dec-2023 15:35:11 UTC] PHP Warning:  Undefined array key "stripe" in /var/www/html/wp-content/plugins/ultimate-member/includes/core/class-setup.php on line 210
```


This is how I register the predefined page:
```
add_filter( 'um_core_pages', 'add_predefined_pages' );
 function add_predefined_pages( $pages ) {
		$pages['payment-successful'] = array(
			'title'   => __( 'Payment successful', 'um-stripe' ),
			'content' => '[ultimatemember_stripe_checkout_order_details]',
		);
		return $pages;
}
```
