### PR TITLE
Body styles (CU-86cu8khqt)

### DIFF
--- a/includes/core/class-shortcodes.php
+++ b/includes/core/class-shortcodes.php
@@ -257,7 +257,7 @@ if ( ! class_exists( 'um\core\Shortcodes' ) ) {
 
 			foreach ( $array as $slug => $info ) {
 				if ( um_is_core_page( $slug ) ) {
-					$classes[] = 'um';
+					$classes[] = 'um-page';
 					$classes[] = 'um-page-' . $slug;
 
 					if ( is_user_logged_in() ) {


### PR DESCRIPTION
The `um` class has been removed from the body classes to fix page styling.