### PR TITLE
Fixed reset url hash

### DIFF
--- a/includes/core/class-mail.php
+++ b/includes/core/class-mail.php
@@ -351,8 +351,8 @@ if ( ! class_exists( 'um\core\Mail' ) ) {
 			 */
 			$message = apply_filters( 'um_email_send_message_content', $message, $slug, $args );
 
-			add_filter( 'um_template_tags_patterns_hook', array( &$this, 'add_placeholder' ) );
-			add_filter( 'um_template_tags_replaces_hook', array( &$this, 'add_replace_placeholder' ) );
+//			add_filter( 'um_template_tags_patterns_hook', array( &$this, 'add_placeholder' ) );
+//			add_filter( 'um_template_tags_replaces_hook', array( &$this, 'add_replace_placeholder' ) );
 
 			// Convert tags in email template.
 			return um_convert_tags( $message, $args );
@@ -421,8 +421,8 @@ if ( ! class_exists( 'um\core\Mail' ) ) {
 			$mail_from_addr    = UM()->options()->get( 'mail_from_addr' ) ? UM()->options()->get( 'mail_from_addr' ) : get_bloginfo( 'admin_email' );
 			$this->headers     = 'From: ' . stripslashes( $mail_from ) . ' <' . $mail_from_addr . '>' . "\r\n";
 
-			add_filter( 'um_template_tags_patterns_hook', array( UM()->mail(), 'add_placeholder' ) );
-			add_filter( 'um_template_tags_replaces_hook', array( UM()->mail(), 'add_replace_placeholder' ) );
+			add_filter( 'um_template_tags_patterns_hook', array( $this, 'add_placeholder' ) );
+			add_filter( 'um_template_tags_replaces_hook', array( $this, 'add_replace_placeholder' ) );
 
 			/**
 			 * Filters email notification subject.

--- a/includes/core/class-password.php
+++ b/includes/core/class-password.php
@@ -38,20 +38,25 @@ if ( ! class_exists( 'um\core\Password' ) ) {
 		 *
 		 * @return bool|string
 		 */
-		function reset_url() {
+		public function reset_url() {
+			static $reset_key = null;
+
 			$user_id = um_user( 'ID' );
 
 			delete_option( "um_cache_userdata_{$user_id}" );
 
-			//new reset password key via WordPress native field. It maybe already exists here but generated twice to make sure that emailed with a proper and fresh hash
+			// New reset password key via WordPress native field. It maybe already exists here but generated twice to make sure that emailed with a proper and fresh hash.
+			// But doing that only once in 1 request using static variable. Different email placeholders can use reset_url() and we have to use 1 time generated to avoid invalid keys.
 			$user_data = get_userdata( $user_id );
-			$key       = UM()->user()->maybe_generate_password_reset_key( $user_data );
+			if ( empty( $reset_key ) ) {
+				$reset_key = UM()->user()->maybe_generate_password_reset_key( $user_data );
+			}
 
 			// this link looks like WordPress native link e.g. wp-login.php?action=rp&key={hash}&login={user_login}
 			$url = add_query_arg(
 				array(
 					'act'   => 'reset_password',
-					'hash'  => $key,
+					'hash'  => $reset_key,
 					'login' => $user_data->user_login,
 				),
 				um_get_core_page( 'password-reset' )


### PR DESCRIPTION
Different email placeholders can use reset_url() and we have to use 1 time generated to avoid invalid keys.
The reset URL hash has been generated twice and we have the wrong hash in the reset password email.