### PR TITLE
A Warning if New Password is blank

### DIFF
--- a/includes/core/class-password.php
+++ b/includes/core/class-password.php
@@ -490,6 +490,7 @@ if ( ! class_exists( 'um\core\Password' ) ) {
 
 			if ( isset( $args['user_password'] ) && empty( $args['user_password'] ) ) {
 				UM()->form()->add_error( 'user_password', __( 'You must enter a new password', 'ultimate-member' ) );
+				return;
 			}
 
 			if ( isset( $args['user_password'] ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -166,6 +166,10 @@ No specific extensions are needed. But we highly recommended keep active these P
 
 IMPORTANT: PLEASE UPDATE THE PLUGIN TO AT LEAST VERSION 2.6.7 IMMEDIATELY. VERSION 2.6.7 PATCHES SECURITY PRIVILEGE ESCALATION VULNERABILITY. PLEASE SEE [THIS ARTICLE](https://docs.ultimatemember.com/article/1866-security-incident-update-and-recommended-actions) FOR MORE INFORMATION
 
+= 2.8.4: March xx, 2024 =
+
+
+
 = 2.8.3: February 19, 2024 =
 
 * Enhancements:

--- a/ultimate-member.php
+++ b/ultimate-member.php
@@ -3,7 +3,7 @@
  * Plugin Name: Ultimate Member
  * Plugin URI: http://ultimatemember.com/
  * Description: The easiest way to create powerful online communities and beautiful user profiles with WordPress
- * Version: 2.8.3
+ * Version: 2.8.4-alpha
  * Author: Ultimate Member
  * Author URI: http://ultimatemember.com/
  * Text Domain: ultimate-member


### PR DESCRIPTION
Stop the "New Password" validation if it is empty to avoid a warning: `strpos(): Empty needle`