### PR TITLE
- fixed parse html on 'um_message_content'

### DIFF
--- a/includes/core/class-access.php
+++ b/includes/core/class-access.php
@@ -1248,7 +1248,7 @@ if ( ! class_exists( 'um\core\Access' ) ) {
 							if ( $block['attrs']['um_message_type'] == '1' ) {
 								$block_content = $default_message;
 							} elseif ( $block['attrs']['um_message_type'] == '2' ) {
-								$block_content = isset( $block['attrs']['um_message_content'] ) ? esc_textarea( $block['attrs']['um_message_content'] ) : '';
+								$block_content = isset( $block['attrs']['um_message_content'] ) ? html_entity_decode(esc_textarea( $block['attrs']['um_message_content'] )) : '';
 							}
 						}
 					} else {
@@ -1272,7 +1272,7 @@ if ( ! class_exists( 'um\core\Access' ) ) {
 								if ( $block['attrs']['um_message_type'] == '1' ) {
 									$block_content = $default_message;
 								} elseif ( $block['attrs']['um_message_type'] == '2' ) {
-									$block_content = isset( $block['attrs']['um_message_content'] ) ? esc_textarea( $block['attrs']['um_message_content'] ) : '';
+									$block_content = isset( $block['attrs']['um_message_content'] ) ? html_entity_decode(esc_textarea( $block['attrs']['um_message_content'] )) : '';
 								}
 							}
 						}
@@ -1286,7 +1286,7 @@ if ( ! class_exists( 'um\core\Access' ) ) {
 							if ( $block['attrs']['um_message_type'] == '1' ) {
 								$block_content = $default_message;
 							} elseif ( $block['attrs']['um_message_type'] == '2' ) {
-								$block_content = isset( $block['attrs']['um_message_content'] ) ? esc_textarea( $block['attrs']['um_message_content'] ) : '';
+								$block_content = isset( $block['attrs']['um_message_content'] ) ? html_entity_decode(esc_textarea( $block['attrs']['um_message_content'] )) : '';
 							}
 						}
 					}


### PR DESCRIPTION
when i use html code in Custom Restrict Content message for gutenberg block on frontend thts display html insted of render it 
so this is fix the problem