### PR TITLE
Telegram and Discord social links in profile header

### DIFF
--- a/includes/core/class-builtin.php
+++ b/includes/core/class-builtin.php
@@ -1074,6 +1074,8 @@ if ( ! class_exists( 'um\core\Builtin' ) ) {
 					'icon'       => 'fab fa-telegram',
 					'validate'   => 'telegram_url',
 					'url_text'   => 'Telegram',
+					'advanced'   => 'social',
+					'color'      => '#24A1DE',
 					'match'      => 'https://t.me/',
 				),
 
@@ -1090,7 +1092,9 @@ if ( ! class_exists( 'um\core\Builtin' ) ) {
 					'url_text'   => __( 'Discord', 'ultimate-member' ),
 					'url_rel'    => 'nofollow',
 					'validate'   => 'discord',
+					'advanced'   => 'social',
 					'color'      => '#7289da',
+					'match'      => 'https://discord.com/users/',
 				),
 
 				'tiktok'               => array(


### PR DESCRIPTION
Fixed displaying Telegram and Discord social links in profile header.

Example:
![2024-06-14_220021](https://github.com/ultimatemember/ultimatemember/assets/78854651/cf0e9a35-2330-486a-add3-807af5276b5a)