### PR TITLE
Fixed: UM links to empty phone numbers

### DIFF
--- a/includes/core/class-form.php
+++ b/includes/core/class-form.php
@@ -856,15 +856,13 @@ if ( ! class_exists( 'um\core\Form' ) ) {
 										case 'vimeo_video':
 										case 'soundcloud_track':
 										case 'spotify':
+										case 'tel':
 											$form[ $k ] = sanitize_text_field( $form[ $k ] );
 											break;
 										case 'multiselect':
 										case 'radio':
 										case 'checkbox':
 											$form[ $k ] = is_array( $form[ $k ] ) ? array_map( 'sanitize_text_field', $form[ $k ] ) : sanitize_text_field( $form[ $k ] );
-											break;
-										case 'tel':
-											$form[ $k ] = sanitize_text_field( $field );
 											break;
 									}
 								}

--- a/includes/core/class-form.php
+++ b/includes/core/class-form.php
@@ -863,6 +863,9 @@ if ( ! class_exists( 'um\core\Form' ) ) {
 										case 'checkbox':
 											$form[ $k ] = is_array( $form[ $k ] ) ? array_map( 'sanitize_text_field', $form[ $k ] ) : sanitize_text_field( $form[ $k ] );
 											break;
+										case 'tel':
+											$form[ $k ] = sanitize_text_field( $field );
+											break;
 									}
 								}
 							}

--- a/includes/core/um-filters-fields.php
+++ b/includes/core/um-filters-fields.php
@@ -141,16 +141,17 @@ add_filter( 'um_profile_field_filter_hook__vimeo_video', 'um_profile_field_filte
  * @param $value
  * @param $data
  *
- * @return int|string
+ * @return string
  */
 function um_profile_field_filter_hook__phone( $value, $data ) {
-	$value = str_replace( '+', '', $value );
-	$value = trim( $value );
+	$test_value = str_replace( '+', '', $value );
+	$test_value = trim( $test_value );
 
-	if ( ! $value ) {
+	if ( ! $test_value ) {
 		return '';
 	}
 
+	$value = trim( $value );
 	$value = '<a href="' . esc_url( 'tel:' . $value ) . '" rel="nofollow" title="' . esc_attr( $data['title'] ) . '">' . esc_html( $value ) . '</a>';
 	return $value;
 }

--- a/includes/core/um-filters-fields.php
+++ b/includes/core/um-filters-fields.php
@@ -144,7 +144,7 @@ add_filter( 'um_profile_field_filter_hook__vimeo_video', 'um_profile_field_filte
  * @return string
  */
 function um_profile_field_filter_hook__phone( $value, $data ) {
-	if ( ! trim( str_replace( '+', '', $value ) ) ) {
+	if ( empty( trim( str_replace( '+', '', $value ) ) ) ) {
 		return '';
 	}
 

--- a/includes/core/um-filters-fields.php
+++ b/includes/core/um-filters-fields.php
@@ -144,6 +144,13 @@ add_filter( 'um_profile_field_filter_hook__vimeo_video', 'um_profile_field_filte
  * @return int|string
  */
 function um_profile_field_filter_hook__phone( $value, $data ) {
+	$value = str_replace( '+', '', $value );
+	$value = trim( $value );
+
+	if ( ! $value ) {
+		return '';
+	}
+
 	$value = '<a href="' . esc_url( 'tel:' . $value ) . '" rel="nofollow" title="' . esc_attr( $data['title'] ) . '">' . esc_html( $value ) . '</a>';
 	return $value;
 }

--- a/includes/core/um-filters-fields.php
+++ b/includes/core/um-filters-fields.php
@@ -144,10 +144,7 @@ add_filter( 'um_profile_field_filter_hook__vimeo_video', 'um_profile_field_filte
  * @return string
  */
 function um_profile_field_filter_hook__phone( $value, $data ) {
-	$test_value = str_replace( '+', '', $value );
-	$test_value = trim( $test_value );
-
-	if ( ! $test_value ) {
+	if ( ! trim( str_replace( '+', '', $value ) ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
Issue: #1515 UM links to empty phone numbers

Empty field is displaying due to missing conditions. This condition fixes it;
```php
if ( empty( trim( str_replace( '+', '', $value ) ) ) ) {
  return '';
}
```
- str_replace( '+', '', $value ): Removes all + characters from $value.
- trim( ... ): Trims whitespace from the resulting string.
- empty( ... ): Checks if the resulting string is empty.

Also tel field was added and sanitized upon updating profile to other similar fields
```php
case 'tel':
```