### PR TITLE
Fix for fetch user

### DIFF
--- a/includes/core/class-roles-capabilities.php
+++ b/includes/core/class-roles-capabilities.php
@@ -703,7 +703,10 @@ if ( ! class_exists( 'um\core\Roles_Capabilities' ) ) {
 
 			$return = 1;
 
-			um_fetch_user( get_current_user_id() );
+			if ( get_current_user_id() !== um_user( 'ID' ) ) {
+				$temp_id = um_user( 'ID' );
+				um_fetch_user( get_current_user_id() );
+			}
 
 			$current_user_roles = $this->get_all_user_roles( $user_id );
 
@@ -744,7 +747,9 @@ if ( ! class_exists( 'um\core\Roles_Capabilities' ) ) {
 
 			}
 
-			um_fetch_user( $user_id );
+			if ( ! empty( $temp_id ) ) {
+				um_fetch_user( $temp_id );
+			}
 
 			return $return;
 		}

--- a/includes/core/um-filters-avatars.php
+++ b/includes/core/um-filters-avatars.php
@@ -36,9 +36,16 @@ function um_get_avatar( $avatar = '', $id_or_email='', $size = '96', $avatar_cla
 	if ( empty( $user_id ) )
 		return $avatar;
 
-	um_fetch_user( $user_id );
+	if ( $user_id !== um_user( 'ID' ) ) {
+		$temp_id = um_user( 'ID' );
+		um_fetch_user( $user_id );
+	}
 
 	$avatar = um_user( 'profile_photo', $size );
+
+	if ( ! empty( $temp_id ) ) {
+		um_fetch_user( $temp_id );
+	}
 
 	return $avatar;
 }

--- a/includes/um-short-functions.php
+++ b/includes/um-short-functions.php
@@ -2169,7 +2169,9 @@ function um_get_default_avatar_uri() {
 function um_get_user_avatar_data( $user_id = '', $size = '96' ) {
 	if ( empty( $user_id ) ) {
 		$user_id = um_user( 'ID' );
-	} else {
+	}
+	if ( $user_id !== um_user( 'ID' ) ) {
+		$temp_id = um_user( 'ID' );
 		um_fetch_user( $user_id );
 	}
 
@@ -2264,6 +2266,10 @@ function um_get_user_avatar_data( $user_id = '', $size = '96' ) {
 	 * ?>
 	 */
 	$data['alt'] = apply_filters( "um_avatar_image_alternate_text", um_user( "display_name" ), $data );
+
+	if ( ! empty( $temp_id ) ) {
+		um_fetch_user( $temp_id );
+	}
 
 	return $data;
 }


### PR DESCRIPTION
Fixed incorrect usage of the `um_fetch_user` function. 

This issue influences the user capabilities and make it impossible to edit users at the _wp-admin > Users_ page. See screenshots.

Issue:
![issue](https://github.com/user-attachments/assets/d68951e1-3b22-4269-a186-823317753eeb)

Fixed:
![fixed](https://github.com/user-attachments/assets/add671e7-30ce-4700-b2b8-8df5671e1b85)