### PR TITLE
Fixes 'um_dispatch_email' action #1589

### DIFF
--- a/includes/action-scheduler/class-init.php
+++ b/includes/action-scheduler/class-init.php
@@ -53,6 +53,10 @@ if ( ! class_exists( 'um\action_scheduler\Init' ) ) {
 			}
 		}
 
+		public function is_enabled() {
+			return $this->enabled;
+		}
+
 		public function add_notice() {
 			UM()->admin()->notices()->add_notice(
 				'um-action-scheduler',

--- a/includes/common/actions/class-emails.php
+++ b/includes/common/actions/class-emails.php
@@ -18,6 +18,7 @@ if ( ! class_exists( 'um\common\actions\Emails' ) ) {
 
 		public function __construct() {
 			add_action( 'um_dispatch_email', array( $this, 'send' ), 10, 3 );
+			add_action( 'um_before_email_notification_sending', array( $this, 'before_email_send' ), 10, 2 );
 		}
 
 		/**
@@ -32,7 +33,40 @@ if ( ! class_exists( 'um\common\actions\Emails' ) ) {
 				return;
 			}
 
+			// @todo Workaround for now. Maybe we need to put base $user_id everytime
+			if ( array_key_exists( 'fetch_user_id', $args ) ) {
+				// When Action Scheduler is enabled, email sending script is located out of basic functionality, so we need to fetch the user for replace placeholders.
+				if ( UM()->maybe_action_scheduler()->is_enabled() ) {
+					um_fetch_user( $args['fetch_user_id'] );
+				}
+				unset( $args['fetch_user_id'] );
+			}
+
 			UM()->mail()->send( $user_email, $template, $args );
+		}
+
+		/**
+		 * Add some custom placeholders when sending via Action Scheduler.
+		 *
+		 * @todo Workaround for now. Maybe we need to handle email placeholders in email class where $user_id is fetched everytime
+		 *
+		 * @param string $email
+		 * @param string $template
+		 *
+		 * @return void
+		 */
+		public function before_email_send( $email, $template ) {
+			if ( ! UM()->maybe_action_scheduler()->is_enabled() ) {
+				return;
+			}
+
+			if ( 'checkmail_email' === $template ) {
+				add_filter( 'um_template_tags_patterns_hook', array( UM()->user(), 'add_activation_placeholder' ) );
+				add_filter( 'um_template_tags_replaces_hook', array( UM()->user(), 'add_activation_replace_placeholder' ) );
+			} elseif ( 'welcome_email' === $template || 'approved_email' === $template || 'resetpw_email' === $template ) {
+				add_filter( 'um_template_tags_patterns_hook', array( UM()->password(), 'add_placeholder' ) );
+				add_filter( 'um_template_tags_replaces_hook', array( UM()->password(), 'add_replace_placeholder' ) );
+			}
 		}
 	}
 }

--- a/includes/common/class-users.php
+++ b/includes/common/class-users.php
@@ -388,7 +388,7 @@ class Users {
 			add_filter( 'um_template_tags_patterns_hook', array( UM()->user(), 'add_activation_placeholder' ) );
 			add_filter( 'um_template_tags_replaces_hook', array( UM()->user(), 'add_activation_replace_placeholder' ) );
 
-			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, 'checkmail_email' ) );
+			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, 'checkmail_email', array( 'fetch_user_id' => $user_id ) ) );
 
 			um_fetch_user( $current_user_id );
 			/**
@@ -456,7 +456,7 @@ class Users {
 			$this->reset_activation_link( $user_id );
 
 			$userdata = get_userdata( $user_id );
-			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, 'inactive_email' ) );
+			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, 'inactive_email', array( 'fetch_user_id' => $user_id ) ) );
 
 			/**
 			 * Fires after User has been deactivated.
@@ -528,7 +528,7 @@ class Users {
 			$this->reset_activation_link( $user_id );
 
 			$userdata = get_userdata( $user_id );
-			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, 'rejected_email' ) );
+			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, 'rejected_email', array( 'fetch_user_id' => $user_id ) ) );
 
 			/**
 			 * Fires after User has been rejected.
@@ -606,7 +606,7 @@ class Users {
 			$this->reset_activation_link( $user_id );
 
 			$userdata = get_userdata( $user_id );
-			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, 'pending_email' ) );
+			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, 'pending_email', array( 'fetch_user_id' => $user_id ) ) );
 
 			/**
 			 * Fires after User has been set as pending admin review.
@@ -697,7 +697,7 @@ class Users {
 			add_filter( 'um_template_tags_patterns_hook', array( UM()->password(), 'add_placeholder' ) );
 			add_filter( 'um_template_tags_replaces_hook', array( UM()->password(), 'add_replace_placeholder' ) );
 
-			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, $email_slug ) );
+			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, $email_slug, array( 'fetch_user_id' => $user_id ) ) );
 
 			um_fetch_user( $current_user_id );
 			/**
@@ -774,7 +774,7 @@ class Users {
 			add_filter( 'um_template_tags_patterns_hook', array( UM()->password(), 'add_placeholder' ) );
 			add_filter( 'um_template_tags_replaces_hook', array( UM()->password(), 'add_replace_placeholder' ) );
 
-			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, 'welcome_email' ) );
+			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, 'welcome_email', array( 'fetch_user_id' => $user_id ) ) );
 
 			um_fetch_user( $current_user_id );
 

--- a/includes/core/class-permalinks.php
+++ b/includes/core/class-permalinks.php
@@ -31,7 +31,8 @@ if ( ! class_exists( 'um\core\Permalinks' ) ) {
 
 			add_action( 'init',  array( &$this, 'check_for_querystrings' ), 1 );
 
-			add_action( 'init',  array( &$this, 'activate_account_via_email_link' ), 1 );
+			// don't use lower than 2 priority because there is sending email inside, but Action Scheduler is init on 1st priority.
+			add_action( 'init',  array( &$this, 'activate_account_via_email_link' ), 2 );
 		}
 
 		/**

--- a/includes/core/class-user.php
+++ b/includes/core/class-user.php
@@ -153,9 +153,9 @@ if ( ! class_exists( 'um\core\User' ) ) {
 			add_action( 'init', array( &$this, 'check_membership' ), 10 );
 
 			if ( is_multisite() ) {
-				add_action( 'wpmu_delete_user', array( &$this, 'delete_user_handler' ), 10, 1 );
+				add_action( 'wpmu_delete_user', array( &$this, 'delete_user_handler' ) );
 			} else {
-				add_action( 'delete_user', array( &$this, 'delete_user_handler' ), 10, 1 );
+				add_action( 'delete_user', array( &$this, 'delete_user_handler' ) );
 			}
 
 			add_action( 'updated_user_meta', array( &$this, 'on_update_usermeta' ), 10, 4 );
@@ -623,14 +623,15 @@ if ( ! class_exists( 'um\core\User' ) ) {
 			// send email notifications
 			if ( $this->send_mail_on_delete ) {
 				$user_email = um_user( 'user_email' );
-				$template   = 'deletion_email';
 
-				UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $user_email, $template ) );
+				// Sending without Action Scheduler, because in the scheduled event the user is already deleted.
+				UM()->mail()->send( $user_email, 'deletion_email' );
 
 				$emails = um_multi_admin_email();
 				if ( ! empty( $emails ) ) {
 					foreach ( $emails as $email ) {
-						UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $email, 'notification_deletion', array( 'admin' => true ) ) );
+						// Sending without Action Scheduler, because in the scheduled event the user is already deleted.
+						UM()->mail()->send( $email, 'notification_deletion', array( 'admin' => true ) );
 					}
 				}
 			}
@@ -1517,10 +1518,10 @@ if ( ! class_exists( 'um\core\User' ) ) {
 
 			$this->maybe_generate_password_reset_key( $userdata );
 
-			add_filter( 'um_template_tags_patterns_hook', array( UM()->password(), 'add_placeholder' ), 10, 1 );
-			add_filter( 'um_template_tags_replaces_hook', array( UM()->password(), 'add_replace_placeholder' ), 10, 1 );
+			add_filter( 'um_template_tags_patterns_hook', array( UM()->password(), 'add_placeholder' ) );
+			add_filter( 'um_template_tags_replaces_hook', array( UM()->password(), 'add_replace_placeholder' ) );
 
-			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, 'resetpw_email' ) );
+			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $userdata->user_email, 'resetpw_email', array( 'fetch_user_id' => um_user( 'ID' ) ) ) );
 		}
 
 
@@ -1534,7 +1535,7 @@ if ( ! class_exists( 'um\core\User' ) ) {
 				um_fetch_user( $user_id );
 			}
 
-			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( um_user( 'user_email' ), 'changedpw_email' ) );
+			UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( um_user( 'user_email' ), 'changedpw_email', array( 'fetch_user_id' => $user_id ) ) );
 
 			if ( ! empty( $user_id ) ) {
 				um_reset_user();

--- a/includes/core/um-actions-account.php
+++ b/includes/core/um-actions-account.php
@@ -593,7 +593,7 @@ function um_account_updated_notification( $user_id, $changed ) {
 	if ( 'password' !== $_POST['_um_account_tab'] || ! UM()->options()->get( 'changedpw_email_on' ) ) {
 		// Avoid email duplicates (account changed and password changed) on the password change tab.
 		um_fetch_user( $user_id );
-		UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( um_user( 'user_email' ), 'changedaccount_email' ) );
+		UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( um_user( 'user_email' ), 'changedaccount_email', array( 'fetch_user_id' => $user_id ) ) );
 	}
 	// phpcs:enable WordPress.Security.NonceVerification
 }

--- a/includes/core/um-actions-register.php
+++ b/includes/core/um-actions-register.php
@@ -120,9 +120,9 @@ function um_send_registration_notification( $user_id ) {
 	if ( ! empty( $emails ) ) {
 		foreach ( $emails as $email ) {
 			if ( 'pending' !== $registration_status ) {
-				UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $email, 'notification_new_user', array( 'admin' => true ) ) );
+				UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $email, 'notification_new_user', array( 'admin' => true, 'fetch_user_id' => $user_id ) ) );
 			} else {
-				UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $email, 'notification_review', array( 'admin' => true ) ) );
+				UM()->maybe_action_scheduler()->enqueue_async_action( 'um_dispatch_email', array( $email, 'notification_review', array( 'admin' => true, 'fetch_user_id' => $user_id ) ) );
 			}
 		}
 	}


### PR DESCRIPTION
* Sending email notifications directly (without Action Scheduler) on user delete action;
* Changed activation handler priority for integration with Action Scheduler
* Added 'fetch_user_id' argument for fetching the necessary user before email sending when Action Scheduler is active.