### PR TITLE
Action Listeners locked to manage_options

### DIFF
--- a/includes/admin/class-actions-listener.php
+++ b/includes/admin/class-actions-listener.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'um\admin\Actions_Listener' ) ) {
 		 * @since 2.8.7
 		 */
 		public function actions_listener() {
-			if ( ! current_user_can( 'manage_options' ) ) {
+			if ( ! current_user_can( 'manage_options' ) && ! current_user_can( 'edit_users' ) ) {
 				return;
 			}
 


### PR DESCRIPTION
Fixed capabilities in the `actions_listener` method. Users who have the `edit_users` capability are able to change user statuses.