### PR TITLE
Password set in Dashboard can't be used for UM login or vice versa (CU-86cxwy7ww)

### DIFF
--- a/includes/core/class-account.php
+++ b/includes/core/class-account.php
@@ -348,7 +348,21 @@ if ( ! class_exists( 'um\core\Account' ) ) {
 
 			if ( um_submitting_account_page() ) {
 
-				UM()->form()->post_form = wp_unslash( $_POST );
+				$formdata = wp_unslash( $_POST );
+				if ( isset( $_POST['user_password'] ) ) {
+					$formdata['user_password'] = trim( $_POST['user_password'] );
+				}
+				if ( isset( $_POST['confirm_user_password'] ) ) {
+					$formdata['confirm_user_password'] = trim( $_POST['confirm_user_password'] );
+				}
+				if ( isset( $_POST['current_user_password'] ) ) {
+					$formdata['current_user_password'] = trim( $_POST['current_user_password'] );
+				}
+				if ( isset( $_POST['single_user_password'] ) ) {
+					$formdata['single_user_password'] = trim( $_POST['single_user_password'] );
+				}
+
+				UM()->form()->post_form = $formdata;
 
 				/**
 				 * UM hook

--- a/includes/core/class-form.php
+++ b/includes/core/class-form.php
@@ -556,6 +556,17 @@ if ( ! class_exists( 'um\core\Form' ) ) {
 				 */
 				do_action( 'um_before_submit_form_post', $this );
 
+				$formdata = wp_unslash( $_POST );
+				if ( isset( $formdata['form_id'] ) ) {
+					$form_id = absint( $formdata['form_id'] );
+					if ( isset( $_POST['user_password-' . $form_id] ) ) {
+						$formdata['user_password-' . $form_id] = trim( $_POST['user_password-' . $form_id] );
+					}
+					if ( isset( $_POST['confirm_user_password-' . $form_id] ) ) {
+						$formdata['confirm_user_password-' . $form_id] = trim( $_POST['confirm_user_password-' . $form_id] );
+					}
+				}
+
 				/* save entire form as global */
 				/**
 				 * Filters $_POST submitted data by the UM login, registration or profile form.
@@ -574,7 +585,7 @@ if ( ! class_exists( 'um\core\Form' ) ) {
 				 * }
 				 * add_filter( 'um_submit_post_form', 'my_submit_post_form' );
 				 */
-				$this->post_form = apply_filters( 'um_submit_post_form', wp_unslash( $_POST ) );
+				$this->post_form = apply_filters( 'um_submit_post_form', $formdata );
 
 				// Validate form submission by honeypot.
 				if ( isset( $this->post_form[ UM()->honeypot ] ) && '' !== $this->post_form[ UM()->honeypot ] ) {

--- a/includes/core/class-password.php
+++ b/includes/core/class-password.php
@@ -337,7 +337,16 @@ if ( ! class_exists( 'um\core\Password' ) ) {
 			}
 
 			if ( $this->is_change_request() ) {
-				UM()->form()->post_form = wp_unslash( $_POST );
+
+				$formdata = wp_unslash( $_POST );
+				if ( isset( $_POST['user_password'] ) ) {
+					$formdata['user_password'] = trim( $_POST['user_password'] );
+				}
+				if ( isset( $_POST['confirm_user_password'] ) ) {
+					$formdata['confirm_user_password'] = trim( $_POST['confirm_user_password'] );
+				}
+
+				UM()->form()->post_form = $formdata;
 
 				/**
 				 * UM hook


### PR DESCRIPTION
Password sanitize has been changed to the standard WordPress one - no `wp_unslash`, only `trim`.