### PR TITLE
Update plugin release date in changelog and readme files

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 ﻿== Changelog ==
 
-= 2.10.0 February 17, 2025 =
+= 2.10.0 February 18, 2025 =
 
 * Enhancements:
 

--- a/readme.txt
+++ b/readme.txt
@@ -167,7 +167,7 @@ No specific extensions are needed. But we highly recommended keep active these P
 
 IMPORTANT: PLEASE UPDATE THE PLUGIN TO AT LEAST VERSION 2.6.7 IMMEDIATELY. VERSION 2.6.7 PATCHES SECURITY PRIVILEGE ESCALATION VULNERABILITY. PLEASE SEE [THIS ARTICLE](https://docs.ultimatemember.com/article/1866-security-incident-update-and-recommended-actions) FOR MORE INFORMATION
 
-= 2.10.0 2025-02-17 =
+= 2.10.0 2025-02-18 =
 
 **Enhancements**
 


### PR DESCRIPTION
Corrected the release date for version 2.10.0 from February 17, 2025, to February 18, 2025, in both the changelog and readme files. No functional changes were made to the plugin.