### PR TITLE
Change email permissions

### DIFF
--- a/includes/core/class-account.php
+++ b/includes/core/class-account.php
@@ -676,8 +676,8 @@ if ( ! class_exists( 'um\core\Account' ) ) {
 						$args = 'user_login,user_email';
 					}
 
-					if ( ! UM()->options()->get( 'account_email' ) && ! um_user( 'can_edit_everyone' ) ) {
-						$args = str_replace(',user_email','', $args );
+					if ( ! UM()->options()->get( 'account_email' ) ) {
+						$args = str_replace( ',user_email', '', $args );
 					}
 
 					if ( $this->current_password_is_required( $id ) ) {


### PR DESCRIPTION
- fixed change email permissions (issue #1679)

@nikitasinelnikov could you check?
I'm not sure if this change is needed. But on the other hand, the user who has a role that allows editing other members' accounts can't visit their account pages and "! um_user( 'can_edit_everyone' )" is an extra check.