### PR TITLE
Refactor deactivation logic to unschedule additional actions

### DIFF
--- a/includes/class-init.php
+++ b/includes/class-init.php
@@ -370,16 +370,18 @@ if ( ! class_exists( 'UM' ) ) {
 			}
 		}
 
-
 		/**
 		 * Plugin Deactivation
 		 *
 		 * @since 2.3
 		 */
-		function deactivation() {
+		public function deactivation() {
 			$this->cron()->unschedule_events();
-		}
 
+			$this->maybe_action_scheduler()->unschedule_all_actions( 'um_dispatch_email' );
+			$this->maybe_action_scheduler()->unschedule_all_actions( 'um_schedule_empty_account_status_check' );
+			$this->maybe_action_scheduler()->unschedule_all_actions( 'um_set_default_account_status' );
+		}
 
 		/**
 		 * Maybe need multisite activation process


### PR DESCRIPTION
Made the `deactivation` method public and added calls to unschedule specific actions related to email dispatch and account status checks. This ensures proper cleanup of scheduled tasks during plugin deactivation.