### PR TITLE
Makedonia country name

### DIFF
--- a/includes/core/class-builtin.php
+++ b/includes/core/class-builtin.php
@@ -1987,7 +1987,7 @@ if ( ! class_exists( 'um\core\Builtin' ) ) {
 						'LT' => __('Lithuania','ultimate-member'),
 						'LU' => __('Luxembourg','ultimate-member'),
 						'MO' => __('Macao','ultimate-member'),
-						'MK' => __('Macedonia, the former Yugoslav Republic of','ultimate-member'),
+						'MK' => __('North Macedonia','ultimate-member'),
 						'MG' => __('Madagascar','ultimate-member'),
 						'MW' => __('Malawi','ultimate-member'),
 						'MY' => __('Malaysia','ultimate-member'),


### PR DESCRIPTION
- fixed Makedonia country name (https://wordpress.org/support/topic/trouble-with-flag-of-north-macedonia/#post-18517366). The new country name since 2019