### PR TITLE
Fix: exclude empty meta values in directory filtering

### DIFF
--- a/includes/core/class-member-directory.php
+++ b/includes/core/class-member-directory.php
@@ -995,16 +995,15 @@ if ( ! class_exists( 'um\core\Member_Directory' ) ) {
 			$range = false;
 
 			switch ( $filter ) {
-
-				default: {
-
+				default:
 					$meta = $wpdb->get_row(
 						$wpdb->prepare(
 							"SELECT MIN( CONVERT( meta_value, DECIMAL ) ) as min_meta,
 							MAX( CONVERT( meta_value, DECIMAL ) ) as max_meta,
 							COUNT( DISTINCT meta_value ) as amount
 							FROM {$wpdb->usermeta}
-							WHERE meta_key = %s",
+							WHERE meta_key = %s AND
+								  meta_value != ''",
 							$filter
 						),
 						ARRAY_A
@@ -1016,10 +1015,9 @@ if ( ! class_exists( 'um\core\Member_Directory' ) ) {
 
 					$range = apply_filters( 'um_member_directory_filter_slider_common', $range, $directory_data, $filter );
 					$range = apply_filters( "um_member_directory_filter_{$filter}_slider", $range, $directory_data );
-
 					break;
-				}
-				case 'birth_date': {
+
+				case 'birth_date':
 					$meta = $wpdb->get_row(
 						"SELECT MIN( meta_value ) as min_meta,
 						MAX( meta_value ) as max_meta,
@@ -1033,15 +1031,12 @@ if ( ! class_exists( 'um\core\Member_Directory' ) ) {
 					if ( isset( $meta['min_meta'] ) && isset( $meta['max_meta'] ) && isset( $meta['amount'] ) && $meta['amount'] > 1 ) {
 						$range = array( $this->borndate( strtotime( $meta['max_meta'] ) ), $this->borndate( strtotime( $meta['min_meta'] ) ) );
 					}
-
 					break;
-				}
 
 			}
 
 			return $range;
 		}
-
 
 		/**
 		 * @param $filter


### PR DESCRIPTION
Previously, empty `meta_value` entries were included in the query, potentially causing inaccurate results. This update adds a condition to exclude empty `meta_value` entries, ensuring more reliable directory filtering.