### PR TITLE
Unset old option in the settings_structure

### DIFF
--- a/includes/admin/core/class-admin-settings.php
+++ b/includes/admin/core/class-admin-settings.php
@@ -2435,7 +2435,12 @@ if ( ! class_exists( 'um\admin\core\Admin_Settings' ) ) {
 					unset( $this->settings_structure['appearance']['sections']['']['form_sections']['fields']['fields'][4], $this->settings_structure['appearance']['sections']['']['form_sections']['fields']['fields'][5] );
 
 					// removed "Menu icons in desktop view".
-					unset( $this->settings_structure['appearance']['sections']['profile_menu']['fields'][ count( $this->settings_structure['appearance']['sections']['profile_menu']['fields'] ) - 1 ] );
+					foreach ( $this->settings_structure['appearance']['sections']['profile_menu']['fields'] as $profile_menu_index => $profile_menu_field ) {
+						if ( isset( $profile_menu_field['id'] ) && 'profile_menu_icons' === $profile_menu_field['id'] ) {
+							unset( $this->settings_structure['appearance']['sections']['profile_menu']['fields'][ $profile_menu_index ] );
+							break;
+						}
+					}
 
 					unset(
 						$this->settings_structure['appearance']['sections']['']['form_sections']['profile_photo']['fields'],


### PR DESCRIPTION
Fixed the unset old option in the settings_structure. In the Profile tab extension, the last option is the profile_tabs_order.
This code unsets the wrong option with the activated extension:
```php
unset( $this->settings_structure['appearance']['sections']['profile_menu']['fields'][ count( $this->settings_structure['']['sections']['profile_menu']['fields'] ) - 1 ] );
``` 
@nikitasinelnikov I think we need to change the unset code for other extensions.