### PR TITLE
Blocklist for blocks restrictions

### DIFF
--- a/assets/js/admin/block-restrictions.js
+++ b/assets/js/admin/block-restrictions.js
@@ -9,6 +9,19 @@ function um_admin_blocks_custom_fields( um_condition_fields, props ) {
 	return wp.hooks.applyFilters( 'um_admin_blocks_custom_fields', [], um_condition_fields, props );
 }
 function um_add_restriction_attributes( settings, name ) {
+	// Some blocks have a strict attribute scheme.
+	// They reject any attributes that were not originally defined in them.
+	// When the editor tries to render such a block, the server sees an unfamiliar
+	// attribute um_is_restrict and returns a 400 error, prohibiting "foreign" properties.
+	const excludedPrefixes = [
+		'llms/'
+	];
+
+	// Check the blocklist of prefixes.
+	if ( excludedPrefixes.some( prefix => name.startsWith( prefix ) ) ) {
+		return settings;
+	}
+
 	// add attributes for all blocks
 	const restrictionAttributes = {
 		um_is_restrict: {


### PR DESCRIPTION
- Some blocks have a strict attribute scheme. They reject any attributes that were not originally defined in them. When the editor tries to render such a block, the server sees an unfamiliar attribute um_is_restrict and returns a 400 error, prohibiting "foreign" properties. As a solution, I have added a blocklist for plugins for now