### PR TITLE
Fix invalid 'start_of_week' handling in weekly events logic

### DIFF
--- a/includes/core/class-cron.php
+++ b/includes/core/class-cron.php
@@ -80,7 +80,9 @@ if ( ! class_exists( 'um\core\Cron' ) ) {
 		 */
 		private function weekly_events() {
 			$sunday_start   = wp_date( 'w' );
-			$week_start     = $sunday_start - absint( get_option( 'start_of_week' ) );
+			$start_of_week  = get_option( 'start_of_week', 0 );
+			$start_of_week  = is_numeric( $start_of_week ) ? $start_of_week : 0;
+			$week_start     = $sunday_start - absint( $start_of_week );
 			$week_start_day = strtotime( '-' . $week_start . ' days' );
 			$time           = mktime( 0, 0, 0, wp_date( 'm', $week_start_day ), wp_date( 'd', $week_start_day ), wp_date( 'Y', $week_start_day ) );
 			if ( ! wp_next_scheduled( 'um_weekly_scheduled_events' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -178,6 +178,8 @@ IMPORTANT: PLEASE UPDATE THE PLUGIN TO AT LEAST VERSION 2.6.7 IMMEDIATELY. VERSI
 **Bugfixes**
 
 * Fixed: Changed the view and the edit user profile links in the comments section on the frontend.
+* Fixed: `Contains` conditional logic operand when value is array.
+* Fixed: Integer validation for the 'start_of_week' WP native setting.
 
 = 2.10.5 2025-06-25 =
 


### PR DESCRIPTION
Ensure 'start_of_week' option is validated as numeric to prevent incorrect calculations. This fixes potential issues when non-numeric values are stored in the option.