### PR TITLE
Fix cover image size handling and add fallback for invalid sizes. Reviewed #1736

### DIFF
--- a/includes/core/class-member-directory-meta.php
+++ b/includes/core/class-member-directory-meta.php
@@ -1104,8 +1104,14 @@ if ( ! class_exists( 'um\core\Member_Directory_Meta' ) ) {
 			$pagination_data = $this->calculate_pagination( $directory_data, $total_users );
 
 			$sizes = UM()->options()->get( 'cover_thumb_sizes' );
+			// Ensure we have valid sizes array and handle case when only one size is defined
+			if ( ! is_array( $sizes ) || empty( $sizes ) ) {
+				$sizes = array( 300 ); // fallback to default
+			}
 
-			$this->cover_size = wp_is_mobile() ? $sizes[1] : end( $sizes );
+			// For mobile, use second size if available, otherwise use first size
+			$available_mobile = isset( $sizes[1] ) ? $sizes[1] : $sizes[0];
+			$this->cover_size = wp_is_mobile() ? $available_mobile : end( $sizes );
 
 			$avatar_size       = UM()->options()->get( 'profile_photosize' );
 			$this->avatar_size = str_replace( 'px', '', $avatar_size );

--- a/includes/core/class-member-directory.php
+++ b/includes/core/class-member-directory.php
@@ -2951,8 +2951,14 @@ if ( ! class_exists( 'um\core\Member_Directory' ) ) {
 			$user_ids = apply_filters( 'um_prepare_user_results_array', $user_ids, $this->query_args );
 
 			$sizes = UM()->options()->get( 'cover_thumb_sizes' );
+			// Ensure we have valid sizes array and handle case when only one size is defined
+			if ( ! is_array( $sizes ) || empty( $sizes ) ) {
+				$sizes = array( 300 ); // fallback to default
+			}
 
-			$this->cover_size = wp_is_mobile() ? $sizes[1] : end( $sizes );
+			// For mobile, use second size if available, otherwise use first size
+			$available_mobile = isset( $sizes[1] ) ? $sizes[1] : $sizes[0];
+			$this->cover_size = wp_is_mobile() ? $available_mobile : end( $sizes );
 
 			$this->cover_size = apply_filters( 'um_member_directory_cover_image_size', $this->cover_size, $directory_data );
 


### PR DESCRIPTION
Improved logic to handle cases where the cover image size array is invalid or empty by adding a fallback default size. For mobile devices, the second size is used if available, or the first size is used as a fallback. This ensures proper cover size selection and prevents potential errors.