### PR TITLE
Refactor profile view logic to centralize user access checks

### DIFF
--- a/includes/admin/class-users-columns.php
+++ b/includes/admin/class-users-columns.php
@@ -246,7 +246,7 @@ if ( ! class_exists( 'um\admin\Users_Columns' ) ) {
 			}
 
 			// Remove row actions for now Administrator role and who cannot view profiles of row's user.
-			if ( ! current_user_can( 'manage_options' ) && ! um_can_view_profile( $user_id ) ) {
+			if ( ! current_user_can( 'manage_options' ) && ! UM()->common()->users()->can_view_user( $user_id ) ) {
 				unset( $actions['frontend_profile'], $actions['view_info'], $actions['view'] );
 			}
 

--- a/includes/admin/core/class-admin-builder.php
+++ b/includes/admin/core/class-admin-builder.php
@@ -1072,7 +1072,7 @@ if ( ! class_exists( 'um\admin\core\Admin_Builder' ) ) {
 					break;
 				case 'um_admin_review_registration':
 					// $arg1 means `user_id` variable in this case.
-					if ( ! current_user_can( 'administrator' ) && ! um_can_view_profile( $arg1 ) ) {
+					if ( ! current_user_can( 'manage_options' ) && ! UM()->common()->users()->can_view_user( $arg1 ) ) {
 						$output = '';
 						break;
 					}

--- a/includes/ajax/class-profile.php
+++ b/includes/ajax/class-profile.php
@@ -42,7 +42,7 @@ class Profile {
 			wp_send_json_error( __( 'Wrong nonce', 'ultimate-member' ) );
 		}
 
-		if ( ! um_can_view_profile( $author ) ) {
+		if ( ! UM()->common()->users()->can_view_user( $author ) ) {
 			wp_send_json_error( __( 'You cannot view this user.', 'ultimate-member' ) );
 		}
 
@@ -110,7 +110,7 @@ class Profile {
 			wp_send_json_error( __( 'Wrong nonce', 'ultimate-member' ) );
 		}
 
-		if ( ! um_can_view_profile( $author ) ) {
+		if ( ! UM()->common()->users()->can_view_user( $author ) ) {
 			wp_send_json_error( __( 'You cannot view this user.', 'ultimate-member' ) );
 		}
 

--- a/includes/common/class-users.php
+++ b/includes/common/class-users.php
@@ -1392,6 +1392,10 @@ class Users {
 		}
 
 		$user_id = absint( $user_id );
+		if ( ! self::user_exists( $user_id ) ) {
+			return false;
+		}
+
 		if ( $user_id === $current_user ) {
 			return true;
 		}
@@ -1418,6 +1422,11 @@ class Users {
 		$can_view_user = apply_filters( 'um_can_view_user', null, $user_id, $current_user );
 		if ( ! is_null( $can_view_user ) ) {
 			return $can_view_user;
+		}
+
+		// Check the user account status
+		if ( ! $this->can_current_user_edit_user( $user_id ) && ! $this->has_status( $user_id, 'approved' ) ) {
+			return false;
 		}
 
 		$can_view_user = true;
@@ -1553,6 +1562,10 @@ class Users {
 		}
 
 		$user_id = absint( $user_id );
+		if ( ! self::user_exists( $user_id ) ) {
+			return false;
+		}
+
 		if ( $user_id === $current_user ) {
 			return true;
 		}

--- a/includes/common/class-users.php
+++ b/includes/common/class-users.php
@@ -1457,7 +1457,8 @@ class Users {
 	}
 
 	/**
-	 * Check if user profile is private based on privacy settings
+	 * Check if user profile is private based on privacy settings.
+	 * We don't handle 'account_tab_privacy' option in this function. Privacy cannot be related to the account tab visibility.
 	 *
 	 * @param int $user_id
 	 *

--- a/includes/core/class-roles-capabilities.php
+++ b/includes/core/class-roles-capabilities.php
@@ -704,7 +704,7 @@ if ( ! class_exists( 'um\core\Roles_Capabilities' ) ) {
 						}
 					} else {
 						// don't merge these `if` conditions!
-						if ( ! um_user( 'can_access_private_profile' ) && UM()->user()->is_private_profile( $user_id ) ) {
+						if ( ! UM()->common()->users()->can_view_user( $user_id ) ) {
 							$return = 0;
 						} else {
 							if ( ! um_user( 'can_edit_everyone' ) ) {

--- a/includes/core/class-user.php
+++ b/includes/core/class-user.php
@@ -1735,7 +1735,7 @@ if ( ! class_exists( 'um\core\User' ) ) {
 				// Option "Search engine visibility" in [wp-admin > Settings > Reading]
 				$profile_noindex = true;
 
-			} elseif ( $this->is_private_profile( $user_id ) ) {
+			} elseif ( UM()->common()->users()->is_user_profile_private( $user_id ) ) {
 				// Setting "Profile Privacy" in [Account > Privacy]
 				$profile_noindex = true;
 
@@ -1786,9 +1786,9 @@ if ( ! class_exists( 'um\core\User' ) ) {
 		}
 
 		?>
-		 *
+		 * @todo Please don't use since new UI. We have function for that instead `UM()->common()->users()->is_user_profile_private()`.
 		 */
-		function is_private_profile( $user_id ) {
+		public function is_private_profile( $user_id ) {
 			$privacy = get_user_meta( $user_id, 'profile_privacy', true );
 			if ( $privacy == __( 'Only me', 'ultimate-member' ) || $privacy == 'Only me' ) {
 				return true;
@@ -1827,16 +1827,17 @@ if ( ! class_exists( 'um\core\User' ) ) {
 			return false;
 		}
 
-
 		/**
 		 * Is private
 		 *
 		 * @param $user_id
 		 * @param $case
 		 *
+		 * @todo Please don't use since new UI. We have function for that instead `UM()->common()->users()->can_view_private_user_profile()`.
+		 *
 		 * @return bool
 		 */
-		function is_private_case( $user_id, $case ) {
+		public function is_private_case( $user_id, $case ) {
 			$privacy = get_user_meta( $user_id, 'profile_privacy', true );
 
 			if ( $privacy == $case ) {

--- a/includes/core/um-actions-profile.php
+++ b/includes/core/um-actions-profile.php
@@ -1326,7 +1326,7 @@ function um_pre_profile_shortcode( $args ) {
 		UM()->fields()->viewing = true;
 
 		if ( um_get_requested_user() ) {
-			if ( ! um_is_myprofile() && ! um_can_view_profile( um_get_requested_user() ) ) {
+			if ( ! um_is_myprofile() && ! UM()->common()->users()->can_view_user( um_get_requested_user() ) ) {
 				um_redirect_home( um_get_requested_user(), um_is_myprofile() );
 			}
 

--- a/includes/frontend/class-layouts.php
+++ b/includes/frontend/class-layouts.php
@@ -674,19 +674,8 @@ class Layouts {
 
 		$user_id = absint( $user_id );
 
-		if ( false === $args['ignore_caps'] ) {
-			if ( get_current_user_id() !== $user_id ) {
-				if ( ! um_can_view_profile( $user_id ) ) {
-					return '';
-				}
-
-				if ( ! current_user_can( 'administrator' ) ) {
-					$status = get_user_meta( $user_id, 'account_status', true );
-					if ( 'approved' !== $status ) {
-						return '';
-					}
-				}
-			}
+		if ( false === $args['ignore_caps'] && ! UM()->common()->users()->can_view_user( $user_id ) ) {
+			return '';
 		}
 
 		$title = '';
@@ -1093,19 +1082,8 @@ class Layouts {
 			)
 		);
 
-		if ( false === $args['ignore_caps'] ) {
-			if ( get_current_user_id() !== $user_id ) {
-				if ( ! um_can_view_profile( $user_id ) ) {
-					return '';
-				}
-
-				if ( ! current_user_can( 'administrator' ) ) {
-					$status = get_user_meta( $user_id, 'account_status', true );
-					if ( 'approved' !== $status ) {
-						return '';
-					}
-				}
-			}
+		if ( false === $args['ignore_caps'] && ! UM()->common()->users()->can_view_user( $user_id ) ) {
+			return '';
 		}
 
 		$avatar_args = array(

--- a/includes/um-deprecated-hooks.php
+++ b/includes/um-deprecated-hooks.php
@@ -137,6 +137,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @param {array} $types Allowed image types.
  *
+ * @return {array} Allowed image types.
+ *
  * @since 1.3.x
  * @depecated 3.0.0 Please use 'um_allowed_default_image_types' hook instead.
  * @hook  um_allowed_image_types
@@ -146,6 +148,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Filters the allowed file types.
  *
  * @param {array} $types Allowed file types.
+ *
+ * @return {array} Allowed file types.
  *
  * @since 1.3.x
  * @depecated 3.0.0 Please use 'um_allowed_default_file_types' hook instead.
@@ -157,6 +161,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @param {string} $url Default cover URL.
  *
+ * @return {string} Cover URL.
+ *
  * @since 1.3.67
  * @depecated 3.0.0 Please use 'um_default_cover_url' hook instead.
  * @hook  um_get_default_cover_uri_filter
@@ -167,7 +173,24 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @param {string} $size Default cover photo size for mobile device.
  *
+ * @return {string} Cover photo size.
+ *
  * @since 2.0.0
  * @depecated 3.0.0 Please use 'um_cover_photo_size' hook instead with checking `wp_is_mobile()` inside the callback.
  * @hook  um_mobile_cover_photo
+ */
+
+/**
+ * Filters the users privacy.
+ *
+ * @param {bool}   $is_private_case Does the current case is privacy.
+ * @param {string} $privacy         Privacy value.
+ * @param {int}    $user_id         User ID to check for the current user.
+ *
+ * @return {bool} Current privacy case.
+ *
+ * @since 1.3.x
+ * @depecated 3.0.0 Please use 'um_can_view_private_user_profile' hook instead.
+ *
+ * @hook um_is_private_filter_hook
  */

--- a/includes/um-short-functions.php
+++ b/includes/um-short-functions.php
@@ -1530,7 +1530,8 @@ function um_can_view_field( $data ) {
 
 /**
  * Checks if user can view profile
- * @todo make the function review. Maybe rewrite it.
+ * @todo Please don't use since new UI. We have 2 functions for that instead `UM()->common()->users()->can_view_user` and `UM()->common()->users()->can_view_user_profile()`
+ *
  * @param int $user_id
  *
  * @return bool


### PR DESCRIPTION
Replaced `um_can_view_profile` with `can_view_user` for consistent and robust access control across the plugin. Added additional checks for user existence and account status to improve security and accuracy when determining profile visibility. These changes ensure a more centralized and maintainable way to handle user permissions and profile access.