### PR TITLE
Add license request debugging functionality

### DIFF
--- a/ultimate-member.php
+++ b/ultimate-member.php
@@ -35,6 +35,7 @@ define( 'UM_PLUGIN', plugin_basename( __FILE__ ) );
 define( 'UM_VERSION', $plugin_data['Version'] );
 define( 'UM_PLUGIN_NAME', $plugin_data['Name'] );
 define( 'UM_WP_FUNCTIONS_VERSION', '6.8.0' ); // Updates every major WordPress release.
+define( 'UM_LICENSE_REQUEST_DEBUG', false ); // Set true then need to debug the license request.
 // define( 'UM_DEV_MODE', true );
 
 require_once 'includes/class-functions.php';


### PR DESCRIPTION
Introduced a new method `is_license_debug_enabled` to check debug conditions and added extensive logging for license requests when debugging is enabled. A new constant `UM_LICENSE_REQUEST_DEBUG` was also defined to control debug mode. These changes enhance visibility into license request handling during development or troubleshooting.