### PR TITLE
Fix license validation retries and add improved error logging

### DIFF
--- a/includes/admin/core/class-admin-settings.php
+++ b/includes/admin/core/class-admin-settings.php
@@ -2969,11 +2969,9 @@ if ( ! class_exists( 'um\admin\core\Admin_Settings' ) ) {
 				}
 
 				$request = wp_remote_post( UM()::$store_url, $post_attr );
-				if ( ! is_wp_error( $request ) ) {
-					$request = json_decode( wp_remote_retrieve_body( $request ) );
-				} else {
+				if ( empty( $request ) || is_wp_error( $request ) ) {
 					if ( self::is_license_debug_enabled() ) {
-						error_log( '> Got `wp_error`, try again with `sslverify=true`' );
+						error_log( '> Got `wp_error` or empty request body, try again with `sslverify=true`' );
 					}
 
 					$post_attr['sslverify'] = true;
@@ -2982,6 +2980,20 @@ if ( ! class_exists( 'um\admin\core\Admin_Settings' ) ) {
 					if ( ! is_wp_error( $request ) ) {
 						$request = json_decode( wp_remote_retrieve_body( $request ) );
 					}
+				} else {
+					$request = json_decode( wp_remote_retrieve_body( $request ) );
+					if ( empty( $request ) ) {
+						if ( self::is_license_debug_enabled() ) {
+							error_log( '> Got empty request body, try again with `sslverify=true`' );
+						}
+
+						$post_attr['sslverify'] = true;
+
+						$request = wp_remote_post( UM()::$store_url, $post_attr );
+						if ( ! is_wp_error( $request ) ) {
+							$request = json_decode( wp_remote_retrieve_body( $request ) );
+						}
+					}
 				}
 
 				if ( self::is_license_debug_enabled() ) {
@@ -2989,6 +3001,8 @@ if ( ! class_exists( 'um\admin\core\Admin_Settings' ) ) {
 						error_log( '> Finally got `wp_error`. Details below.' );
 						error_log( '>> Error code: ' . $request->get_error_code() );
 						error_log( '>> Error message: ' . $request->get_error_message() );
+					} elseif ( empty( $request ) ) {
+						error_log( '> Finally got empty UM website response.' );
 					} else {
 						error_log( '### Response from UM website:' );
 						error_log( '>' . maybe_serialize( $request ) );


### PR DESCRIPTION
Previously, requests on license validation did not adequately handle empty responses or WP errors. This update ensures retries are performed with `sslverify=true` in such cases and enhances debug logging to provide clearer error details for troubleshooting.