### PR TITLE
Prevent duplicate password change emails in UM plugin

### DIFF
--- a/includes/core/class-password.php
+++ b/includes/core/class-password.php
@@ -619,6 +619,11 @@ if ( ! class_exists( 'um\core\Password' ) ) {
 				do_action( 'validate_password_reset', $errors, $user );
 
 				if ( ( ! $errors->get_error_code() ) ) {
+					// Don't duplicate UM Password Changed Email and WordPress native email about password changing.
+					add_filter( 'send_password_change_email', '__return_false' ); // TODO maybe unnecessary
+					// TODO make alternative email notification in UM core, but don't use WordPress native
+					// remove_action( 'after_password_reset', 'wp_password_change_notification' ); // TODO uncomment as soon as UM site admin email notification is ready.
+
 					reset_password( $user, trim( $args['user_password'] ) );
 
 					// send the Password Changed Email

--- a/includes/core/um-actions-account.php
+++ b/includes/core/um-actions-account.php
@@ -229,7 +229,8 @@ function um_submit_account_details( $args ) {
 
 		UM()->user()->password_changed();
 
-		add_filter( 'send_password_change_email', '__return_false' );
+		// Don't duplicate UM Password Changed Email and WordPress native email about password changing.
+		add_filter( 'send_password_change_email', '__return_false' ); // TODO maybe unnecessary
 
 		//clear all sessions with old passwords
 		$user = WP_Session_Tokens::get_instance( $args['user_id'] );


### PR DESCRIPTION
Added a filter to disable WordPress native password change emails to avoid duplication with Ultimate Member's custom notifications. Comments and TODOs outline the plan for future improvements and alternative email handling.