### PR TITLE
Wrong info about registration form settings in the Site Health.

### DIFF
--- a/includes/admin/class-site-health.php
+++ b/includes/admin/class-site-health.php
@@ -2130,11 +2130,11 @@ class Site_Health {
 						$debug_info[] = array(
 							'role'             => array(
 								'label' => __( 'User registration role', 'ultimate-member' ),
-								'value' => 0 === absint( get_post_meta( $form_id, '_um_register_role', true ) ) ? $labels['default'] : get_post_meta( $form_id, '_um_register_role', true ),
+								'value' => empty( get_post_meta( $form_id, '_um_register_role', true ) ) ? $labels['default'] : get_post_meta( $form_id, '_um_register_role', true ),
 							),
 							'template'         => array(
 								'label' => __( 'Template', 'ultimate-member' ),
-								'value' => 0 === absint( get_post_meta( $form_id, '_um_register_template', true ) ) ? $labels['default'] : get_post_meta( $form_id, '_um_register_template', true ),
+								'value' => empty( get_post_meta( $form_id, '_um_register_template', true ) ) ? $labels['default'] : get_post_meta( $form_id, '_um_register_template', true ),
 							),
 							'max_width'        => array(
 								'label' => __( 'Max. Width (px)', 'ultimate-member' ),


### PR DESCRIPTION
Fixed "User registration role" and "Template" in the Site Health info for registration forms.

<img width="1156" height="452" alt="issue 3" src="https://github.com/user-attachments/assets/d25b98ba-a5ae-4bb4-b225-6bd87d19aa79" />