### PR TITLE
Fixed the "Allowed roles" setting

### DIFF
--- a/includes/admin/templates/directory/privacy.php
+++ b/includes/admin/templates/directory/privacy.php
@@ -1,7 +1,18 @@
 <?php
+/**
+ * Metabox "Privacy Options" on wp-admin > Ultimate Member > Member Directories > Edit.
+ *
+ * @package um\admin\templates
+ *
+ * @var array   $box
+ * @var WP_Post $object
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
+$_um_privacy_roles_value = get_post_meta( $object->ID, '_um_privacy_roles', true );
 
 $fields = array(
 	array(
@@ -26,7 +37,7 @@ $fields = array(
 		'options'     => UM()->roles()->get_roles(),
 		'placeholder' => __( 'Choose user roles...', 'ultimate-member' ),
 		'conditional' => array( '_um_privacy', '=', '3' ),
-		'value'       => UM()->query()->get_meta_value( '_um_privacy_roles', null, 'na' ),
+		'value'       => empty( $_um_privacy_roles_value ) ? array() : (array) $_um_privacy_roles_value,
 	),
 );
 


### PR DESCRIPTION
The "Allowed roles" setting in the member directory does not display saved values because the function that gets the setting value  processes it as a string while the setting value is an array.

This branch contains a possible solution.

<img width="1900" height="625" alt="2026-02-06_154014" src="https://github.com/user-attachments/assets/8812000f-9886-40b9-b5be-eb702798c5d4" />
