### PR TITLE
fix(directory): exclude filter values from hidden role users

### DIFF
--- a/includes/core/class-member-directory.php
+++ b/includes/core/class-member-directory.php
@@ -858,15 +858,20 @@ if ( ! class_exists( 'um\core\Member_Directory' ) ) {
 					global $wpdb;
 
 					if ( $attrs['metakey'] != 'role_select' ) {
-						$values_array = $wpdb->get_col(
-							$wpdb->prepare(
-								"SELECT DISTINCT meta_value
-								FROM $wpdb->usermeta
-								WHERE meta_key = %s AND
-									  meta_value != ''",
-								$attrs['metakey']
-							)
-						);
+						$directory_roles = get_post_meta( absint( $directory_data['form_id'] ), '_um_roles', true );
+						if ( ! empty( $directory_roles ) && is_array( $directory_roles ) ) {
+							$values_array = $this->get_filter_values_in_roles( $attrs['metakey'], $directory_roles );
+						} else {
+							$values_array = $wpdb->get_col(
+								$wpdb->prepare(
+									"SELECT DISTINCT meta_value
+									FROM $wpdb->usermeta
+									WHERE meta_key = %s AND
+										  meta_value != ''",
+									$attrs['metakey']
+								)
+							);
+						}
 					} else {
 						$users_roles = count_users();
 						$values_array = ( ! empty( $users_roles['avail_roles'] ) && is_array( $users_roles['avail_roles'] ) ) ? array_keys( array_filter( $users_roles['avail_roles'] ) ) : array();
@@ -1128,6 +1133,35 @@ if ( ! class_exists( 'um\core\Member_Directory' ) ) {
 
 			$filter = ob_get_clean();
 			return $filter;
+		}
+
+
+		/**
+		 * Get distinct meta values of a filter collected from users with the roles displayed in the member directory only
+		 *
+		 * @param string $metakey Filter field metakey.
+		 * @param array  $roles   Roles displayed in the member directory.
+		 *
+		 * @return array
+		 */
+		public function get_filter_values_in_roles( $metakey, $roles ) {
+			global $wpdb;
+
+			$capabilities_meta_key = $wpdb->get_blog_prefix() . 'capabilities';
+
+			$roles_clauses = array();
+			foreach ( $roles as $role ) {
+				$roles_clauses[] = $wpdb->prepare( 'usercaps.meta_value LIKE %s', '%"' . $wpdb->esc_like( $role ) . '"%' );
+			}
+
+			return $wpdb->get_col(
+				'SELECT DISTINCT umeta.meta_value
+				FROM ' . $wpdb->usermeta . ' AS umeta
+				INNER JOIN ' . $wpdb->usermeta . ' AS usercaps ON usercaps.user_id = umeta.user_id
+					AND ' . $wpdb->prepare( 'usercaps.meta_key = %s', $capabilities_meta_key ) . '
+					AND ( ' . implode( ' OR ', $roles_clauses ) . ' )
+				WHERE ' . $wpdb->prepare( 'umeta.meta_key = %s AND umeta.meta_value != \'\'', $metakey )
+			);
 		}
 
 

--- a/languages/ultimate-member-en_US.po
+++ b/languages/ultimate-member-en_US.po
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-06T14:13:40+00:00\n"
+"POT-Creation-Date: 2026-08-17T20:37:45+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: ultimate-member\n"
@@ -6997,7 +6997,7 @@ msgstr ""
 #: includes/class-config.php:143
 #: includes/class-config.php:960
 #: includes/class-config.php:1024
-#: includes/core/class-member-directory.php:2681
+#: includes/core/class-member-directory.php:2715
 #: includes/core/um-actions-profile.php:1555
 #: includes/core/um-actions-user.php:19
 msgid "Logout"
@@ -7784,7 +7784,7 @@ msgid "Membership rejected"
 msgstr ""
 
 #: includes/common/class-users.php:198
-#: includes/core/class-member-directory.php:2721
+#: includes/core/class-member-directory.php:2755
 msgid "Undefined"
 msgstr ""
 
@@ -9939,7 +9939,7 @@ msgstr ""
 #: includes/core/class-files.php:662
 #: includes/core/class-form.php:120
 #: includes/core/class-member-directory-meta.php:599
-#: includes/core/class-member-directory.php:2982
+#: includes/core/class-member-directory.php:3016
 #: includes/core/class-user-posts.php:109
 #: includes/core/class-user-posts.php:161
 msgid "Too many requests"
@@ -10104,13 +10104,13 @@ msgstr ""
 
 #: includes/core/class-member-directory-meta.php:607
 #: includes/core/class-member-directory-meta.php:612
-#: includes/core/class-member-directory.php:2988
-#: includes/core/class-member-directory.php:2994
+#: includes/core/class-member-directory.php:3022
+#: includes/core/class-member-directory.php:3028
 msgid "Wrong member directory data"
 msgstr ""
 
 #: includes/core/class-member-directory-meta.php:617
-#: includes/core/class-member-directory.php:2998
+#: includes/core/class-member-directory.php:3032
 msgid "You cannot see this member directory"
 msgstr ""
 
@@ -10216,41 +10216,41 @@ msgstr ""
 
 #. translators: %s: Datetime filter label.
 #. translators: %s: Timepicker filter label.
-#: includes/core/class-member-directory.php:1066
-#: includes/core/class-member-directory.php:1111
+#: includes/core/class-member-directory.php:1071
+#: includes/core/class-member-directory.php:1116
 #, php-format
 msgid "%s From"
 msgstr ""
 
 #. translators: %s: Datetime filter label.
 #. translators: %s: Timepicker filter label.
-#: includes/core/class-member-directory.php:1072
-#: includes/core/class-member-directory.php:1118
+#: includes/core/class-member-directory.php:1077
+#: includes/core/class-member-directory.php:1123
 #, php-format
 msgid "%s To"
 msgstr ""
 
-#: includes/core/class-member-directory.php:1215
-#: includes/core/class-member-directory.php:1216
+#: includes/core/class-member-directory.php:1249
+#: includes/core/class-member-directory.php:1250
 msgid " stars"
 msgstr ""
 
-#: includes/core/class-member-directory.php:1225
+#: includes/core/class-member-directory.php:1259
 msgid "Age:&nbsp;{value} years old"
 msgstr ""
 
-#: includes/core/class-member-directory.php:1226
+#: includes/core/class-member-directory.php:1260
 msgid "Age:&nbsp;{min_range} - {max_range} years old"
 msgstr ""
 
-#: includes/core/class-member-directory.php:2642
-#: includes/core/class-member-directory.php:2670
+#: includes/core/class-member-directory.php:2676
+#: includes/core/class-member-directory.php:2704
 #: includes/core/um-actions-profile.php:1522
 #: includes/core/um-actions-profile.php:1553
 msgid "Edit Profile"
 msgstr ""
 
-#: includes/core/class-member-directory.php:2676
+#: includes/core/class-member-directory.php:2710
 #: includes/core/um-actions-profile.php:1554
 msgid "My Account"
 msgstr ""

--- a/languages/ultimate-member.pot
+++ b/languages/ultimate-member.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-07-06T18:47:12+00:00\n"
+"POT-Creation-Date: 2026-08-17T20:37:44+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: ultimate-member\n"
@@ -6997,7 +6997,7 @@ msgstr ""
 #: includes/class-config.php:143
 #: includes/class-config.php:960
 #: includes/class-config.php:1024
-#: includes/core/class-member-directory.php:2681
+#: includes/core/class-member-directory.php:2715
 #: includes/core/um-actions-profile.php:1555
 #: includes/core/um-actions-user.php:19
 msgid "Logout"
@@ -7784,7 +7784,7 @@ msgid "Membership rejected"
 msgstr ""
 
 #: includes/common/class-users.php:198
-#: includes/core/class-member-directory.php:2721
+#: includes/core/class-member-directory.php:2755
 msgid "Undefined"
 msgstr ""
 
@@ -9939,7 +9939,7 @@ msgstr ""
 #: includes/core/class-files.php:662
 #: includes/core/class-form.php:120
 #: includes/core/class-member-directory-meta.php:599
-#: includes/core/class-member-directory.php:2982
+#: includes/core/class-member-directory.php:3016
 #: includes/core/class-user-posts.php:109
 #: includes/core/class-user-posts.php:161
 msgid "Too many requests"
@@ -10104,13 +10104,13 @@ msgstr ""
 
 #: includes/core/class-member-directory-meta.php:607
 #: includes/core/class-member-directory-meta.php:612
-#: includes/core/class-member-directory.php:2988
-#: includes/core/class-member-directory.php:2994
+#: includes/core/class-member-directory.php:3022
+#: includes/core/class-member-directory.php:3028
 msgid "Wrong member directory data"
 msgstr ""
 
 #: includes/core/class-member-directory-meta.php:617
-#: includes/core/class-member-directory.php:2998
+#: includes/core/class-member-directory.php:3032
 msgid "You cannot see this member directory"
 msgstr ""
 
@@ -10216,41 +10216,41 @@ msgstr ""
 
 #. translators: %s: Datetime filter label.
 #. translators: %s: Timepicker filter label.
-#: includes/core/class-member-directory.php:1066
-#: includes/core/class-member-directory.php:1111
+#: includes/core/class-member-directory.php:1071
+#: includes/core/class-member-directory.php:1116
 #, php-format
 msgid "%s From"
 msgstr ""
 
 #. translators: %s: Datetime filter label.
 #. translators: %s: Timepicker filter label.
-#: includes/core/class-member-directory.php:1072
-#: includes/core/class-member-directory.php:1118
+#: includes/core/class-member-directory.php:1077
+#: includes/core/class-member-directory.php:1123
 #, php-format
 msgid "%s To"
 msgstr ""
 
-#: includes/core/class-member-directory.php:1215
-#: includes/core/class-member-directory.php:1216
+#: includes/core/class-member-directory.php:1249
+#: includes/core/class-member-directory.php:1250
 msgid " stars"
 msgstr ""
 
-#: includes/core/class-member-directory.php:1225
+#: includes/core/class-member-directory.php:1259
 msgid "Age:&nbsp;{value} years old"
 msgstr ""
 
-#: includes/core/class-member-directory.php:1226
+#: includes/core/class-member-directory.php:1260
 msgid "Age:&nbsp;{min_range} - {max_range} years old"
 msgstr ""
 
-#: includes/core/class-member-directory.php:2642
-#: includes/core/class-member-directory.php:2670
+#: includes/core/class-member-directory.php:2676
+#: includes/core/class-member-directory.php:2704
 #: includes/core/um-actions-profile.php:1522
 #: includes/core/um-actions-profile.php:1553
 msgid "Edit Profile"
 msgstr ""
 
-#: includes/core/class-member-directory.php:2676
+#: includes/core/class-member-directory.php:2710
 #: includes/core/um-actions-profile.php:1554
 msgid "My Account"
 msgstr ""


### PR DESCRIPTION
## Summary
Select filters in the member directory collected their values from all users, including users whose roles are excluded from the directory via "User Roles to Display". Such values appeared in the filter dropdown but returned zero members when selected. The values query is now restricted to users with the directory's displayable roles.

Fixes #1717

## Changes
### Member Directory (`includes/core/class-member-directory.php`)
**Before:**
```php
$values_array = $wpdb->get_col(
    $wpdb->prepare(
        "SELECT DISTINCT meta_value
        FROM $wpdb->usermeta
        WHERE meta_key = %s AND
              meta_value != ''",
        $attrs['metakey']
    )
);
```
**After:**
```php
$directory_roles = get_post_meta( absint( $directory_data['form_id'] ), '_um_roles', true );
if ( ! empty( $directory_roles ) && is_array( $directory_roles ) ) {
    $values_array = $this->get_filter_values_in_roles( $attrs['metakey'], $directory_roles );
} else {
    // original unrestricted query kept as-is
}
```
**Why:** When the directory limits displayed users by role, filter options should only contain values that at least one displayed user has. This mirrors how the same function already limits `role_select` options to `_um_roles`. With no roles selected the behavior is unchanged.

The new `get_filter_values_in_roles()` method joins the capabilities usermeta and matches the directory roles with `LIKE '%"role"%'` through `$wpdb->esc_like()`, the same serialized-role matching pattern already used in `includes/core/class-member-directory-meta.php`. Multisite is handled via `get_blog_prefix()`. Applies to the front-end directory, the admin directory builder, and the "Admin filtering" default filters, since all `show_filter()` callers pass the directory `form_id`.

## Testing
**Test 1: Filter values from excluded roles (issue repro)**
1. Add a Country field to the User Profile form.
2. Member Directories > General Options > User Roles to Display: check Subscriber only.
3. Member Directories > Search Options > Choose filter(s) meta to enable: add Country.
4. Set a Contributor user's Country to a unique value (Belgium); no Subscriber user has it.
5. Open the member directory page and open the Country filter dropdown.
Result: Belgium is not listed. Values set by Subscriber users are listed and filtering by them returns the expected members.

**Test 2: No role restriction (regression check)**
1. In the same directory, clear the User Roles to Display selection, save, reload the directory page.
Result: the Country filter lists values from all users again, including Belgium.

PHPCS was run against master for the changed file with no new violations. Manual test of the repro above passed on a packaged build of this branch.