### PR TITLE
Fix(security) - `um convert tags()` escapers

### DIFF
--- a/includes/common/class-secure.php
+++ b/includes/common/class-secure.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'um\common\Secure' ) ) {
 									'{banned_profile_links}',
 								),
 								'tags_replace' => array(
-									$banned_profile_links,
+									wp_kses_post( $banned_profile_links ),
 								),
 							),
 						)

--- a/includes/common/class-users.php
+++ b/includes/common/class-users.php
@@ -419,7 +419,7 @@ class Users {
 							'{account_activation_link}',
 						),
 						'tags_replace'  => array(
-							UM()->permalinks()->activate_url( $user_id ),
+							esc_url( UM()->permalinks()->activate_url( $user_id ) ),
 						),
 					),
 				)
@@ -788,8 +788,8 @@ class Users {
 					'{password}',
 				);
 				$tags_replace = array(
-					$reset_pw_link,
-					__( 'Your set password', 'ultimate-member' ),
+					esc_url( $reset_pw_link ),
+					esc_html__( 'Your set password', 'ultimate-member' ),
 				);
 
 				if ( 'welcome_email' === $email_slug ) {
@@ -798,10 +798,10 @@ class Users {
 
 					$set_password_required = get_user_meta( $user_id, 'um_set_password_required', true );
 					if ( empty( $set_password_required ) || $this->has_status( $user_id, 'pending' ) ) {
-						$tags_replace[] = um_get_core_page( 'login' );
+						$tags_replace[] = esc_url( um_get_core_page( 'login' ) );
 						$tags_replace[] = esc_html__( 'Login to our site', 'ultimate-member' );
 					} else {
-						$tags_replace[] = $reset_pw_link;
+						$tags_replace[] = esc_url( $reset_pw_link );
 						$tags_replace[] = esc_html__( 'Set your password', 'ultimate-member' );
 					}
 				}
@@ -906,16 +906,16 @@ class Users {
 			$reset_pw_link = UM()->password()->reset_url( $user_id );
 
 			$tags_replace = array(
-				$reset_pw_link,
-				__( 'Your set password', 'ultimate-member' ),
+				esc_url( $reset_pw_link ),
+				esc_html__( 'Your set password', 'ultimate-member' ),
 			);
 
 			$set_password_required = get_user_meta( $user_id, 'um_set_password_required', true );
 			if ( empty( $set_password_required ) || $this->has_status( $user_id, 'pending' ) ) {
-				$tags_replace[] = um_get_core_page( 'login' );
+				$tags_replace[] = esc_url( um_get_core_page( 'login' ) );
 				$tags_replace[] = esc_html__( 'Login to our site', 'ultimate-member' );
 			} else {
-				$tags_replace[] = $reset_pw_link;
+				$tags_replace[] = esc_url( $reset_pw_link );
 				$tags_replace[] = esc_html__( 'Set your password', 'ultimate-member' );
 			}
 

--- a/includes/core/class-mail.php
+++ b/includes/core/class-mail.php
@@ -626,10 +626,10 @@ if ( ! class_exists( 'um\core\Mail' ) ) {
 		 * @return array
 		 */
 		public function add_replace_placeholder( $replace_placeholders ) {
-			$replace_placeholders[] = um_user_profile_url();
-			$replace_placeholders[] = get_bloginfo( 'url' );
-			$replace_placeholders[] = um_admin_email();
-			$replace_placeholders[] = um_get_core_page( 'login' );
+			$replace_placeholders[] = esc_url( um_user_profile_url() );
+			$replace_placeholders[] = esc_url( get_bloginfo( 'url' ) );
+			$replace_placeholders[] = esc_html( um_admin_email() );
+			$replace_placeholders[] = esc_url( um_get_core_page( 'login' ) );
 			$replace_placeholders[] = esc_html__( 'Your set password', 'ultimate-member' );
 			return $replace_placeholders;
 		}

--- a/includes/core/class-shortcodes.php
+++ b/includes/core/class-shortcodes.php
@@ -1471,7 +1471,7 @@ if ( ! class_exists( 'um\core\Shortcodes' ) ) {
 		 * @return array
 		 */
 		public function add_replace_placeholder( $replace_placeholders ) {
-			$replace_placeholders[] = um_dynamic_login_page_redirect();
+			$replace_placeholders[] = esc_url( um_dynamic_login_page_redirect() );
 			return $replace_placeholders;
 		}
 	}

--- a/includes/core/class-user.php
+++ b/includes/core/class-user.php
@@ -1491,7 +1491,7 @@ if ( ! class_exists( 'um\core\User' ) ) {
 							'{password_reset_link}',
 						),
 						'tags_replace'  => array(
-							UM()->password()->reset_url( $user_id ),
+							esc_url( UM()->password()->reset_url( $user_id ) ),
 						),
 					),
 				)

--- a/includes/core/um-actions-profile.php
+++ b/includes/core/um-actions-profile.php
@@ -697,7 +697,9 @@ function um_profile_dynamic_meta_desc() {
 		}
 
 		$title       = trim( um_user( 'display_name' ) );
-		$description = um_convert_tags( UM()->options()->get( 'profile_desc' ) );
+		$description = UM()->options()->get( 'profile_desc' );
+		$description = stripslashes( $description ); // todo remove this line as soon as settings will be wp_unslash()-ed during the store to DB.
+		$description = um_convert_tags( $description );
 		$url         = um_user_profile_url( $user_id );
 
 		/**
@@ -787,7 +789,7 @@ function um_profile_dynamic_meta_desc() {
 				'@type'         => 'Person',
 				'name'          => esc_attr( $title ),
 				'alternateName' => um_user( 'user_login' ),
-				'description'   => esc_attr( stripslashes( $description ) ),
+				'description'   => esc_attr( $description ),
 				'image'         => esc_url( $image ),
 				'sameAs'        => array(
 					$url,

--- a/includes/core/um-actions-register.php
+++ b/includes/core/um-actions-register.php
@@ -127,7 +127,7 @@ function um_send_registration_notification( $user_id ) {
 		'tags'          => array(
 			'{submitted_registration}',
 		),
-		'tags_replace'  => um_user_submitted_registration_formatted(),
+		'tags_replace'  => wp_kses_post( um_user_submitted_registration_formatted() ),
 	);
 
 	$emails = um_multi_admin_email();

--- a/includes/core/um-filters-profile.php
+++ b/includes/core/um-filters-profile.php
@@ -1,5 +1,7 @@
-<?php if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
-
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
  * Fix for plugin "The SEO Framework", dynamic profile page title
@@ -11,7 +13,6 @@
  * @return mixed|string
  */
 function um_dynamic_user_profile_pagetitle( $title, $sep = '' ) {
-
 	if ( um_is_core_page( 'user' ) && um_get_requested_user() ) {
 
 		$user_id = um_get_requested_user();
@@ -21,15 +22,15 @@ function um_dynamic_user_profile_pagetitle( $title, $sep = '' ) {
 		}
 
 		$profile_title = UM()->options()->get( 'profile_title' );
+		$profile_title = stripslashes( $profile_title ); // todo remove this line as soon as settings will be wp_unslash()-ed during the store to DB.
 
 		um_fetch_user( um_get_requested_user() );
 
 		$profile_title = um_convert_tags( $profile_title );
 
-		$title = stripslashes( $profile_title );
+		$title = esc_html( $profile_title );
 
 		um_reset_user();
-
 	}
 
 	return $title;
@@ -37,7 +38,6 @@ function um_dynamic_user_profile_pagetitle( $title, $sep = '' ) {
 add_filter( 'the_seo_framework_pro_add_title', 'um_dynamic_user_profile_pagetitle', 100000, 2 );
 add_filter( 'wp_title', 'um_dynamic_user_profile_pagetitle', 100000, 2 );
 add_filter( 'pre_get_document_title', 'um_dynamic_user_profile_pagetitle', 100000, 2 );
-
 
 /**
  * Try and modify the page title in page
@@ -69,7 +69,6 @@ function um_dynamic_user_profile_title( $title, $id = '' ) {
 	return ( strlen( $title ) !== mb_strlen( $title ) ) ? $title : mb_convert_encoding( $title, 'UTF-8' );
 }
 add_filter( 'the_title', 'um_dynamic_user_profile_title', 100000, 2 );
-
 
 /**
  * Fix SEO canonical for the profile page
@@ -118,7 +117,6 @@ function um_get_canonical_url( $canonical_url, $post ) {
 }
 add_filter( 'get_canonical_url', 'um_get_canonical_url', 20, 2 );
 
-
 /**
  * Add cover photo label of file size limit
  *
@@ -137,8 +135,7 @@ function um_change_profile_cover_photo_label( $fields ) {
 	}
 	return $fields;
 }
-add_filter( 'um_predefined_fields_hook', 'um_change_profile_cover_photo_label', 10, 1 );
-
+add_filter( 'um_predefined_fields_hook', 'um_change_profile_cover_photo_label' );
 
 /**
  * Add profile photo label of file size limit
@@ -158,4 +155,4 @@ function um_change_profile_photo_label( $fields ) {
 	}
 	return $fields;
 }
-add_filter( 'um_predefined_fields_hook', 'um_change_profile_photo_label', 10, 1 );
+add_filter( 'um_predefined_fields_hook', 'um_change_profile_photo_label' );

--- a/includes/um-short-functions.php
+++ b/includes/um-short-functions.php
@@ -101,14 +101,12 @@ function um_clean_user_basename( $value ) {
 	return $value;
 }
 
-
 /**
  * Getting replace placeholders array
  *
  * @return array
  */
 function um_replace_placeholders() {
-
 	$search = array(
 		'{display_name}',
 		'{first_name}',
@@ -119,67 +117,58 @@ function um_replace_placeholders() {
 		'{site_name}',
 		'{user_account_link}',
 	);
-
 	/**
-	 * UM hook
+	 * Filters Ultimate Member placeholders used in `um_convert_tags()` function.
 	 *
-	 * @type filter
-	 * @title um_template_tags_patterns_hook
-	 * @description Extend UM placeholders
-	 * @input_vars
-	 * [{"var":"$placeholders","type":"array","desc":"UM Placeholders"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_template_tags_patterns_hook', 'function_name', 10, 1 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_template_tags_patterns_hook', 'my_template_tags_patterns', 10, 1 );
-	 * function my_template_tags_patterns( $placeholders ) {
-	 *     // your code here
-	 *     $placeholders[] = '{my_custom_placeholder}';
-	 *     return $placeholders;
+	 * @param {array} $search Placeholders.
+	 *
+	 * @return {array} Placeholders.
+	 *
+	 * @since 1.3.x
+	 * @hook um_template_tags_patterns_hook
+	 *
+	 * @example <caption>Add placeholder tag to replace it with the same numeric key in the $replace variable.</caption>
+	 * function custom_um_template_tags_patterns_hook( $search ) {
+	 *     $search[] = '{custom_name}';
+	 *     return $search;
 	 * }
-	 * ?>
+	 * add_filter( 'um_template_tags_patterns_hook', 'custom_um_template_tags_patterns_hook' );
 	 */
 	$search = apply_filters( 'um_template_tags_patterns_hook', $search );
 
 	$replace = array(
-		um_user( 'display_name' ),
-		um_user( 'first_name' ),
-		um_user( 'last_name' ),
-		um_user( 'gender' ),
-		um_user( 'user_login' ),
-		um_user( 'user_email' ),
-		UM()->options()->get( 'site_name' ),
-		um_get_core_page( 'account' ),
+		esc_html( um_user( 'display_name' ) ),
+		esc_html( um_user( 'first_name' ) ),
+		esc_html( um_user( 'last_name' ) ),
+		esc_html( um_user( 'gender' ) ),
+		esc_html( um_user( 'user_login' ) ),
+		esc_html( um_user( 'user_email' ) ),
+		esc_html( UM()->options()->get( 'site_name' ) ),
+		esc_url( um_get_core_page( 'account' ) ),
 	);
-
 	/**
-	 * UM hook
+	 * Filters Ultimate Member replace placeholders used in `um_convert_tags()` function.
 	 *
-	 * @type filter
-	 * @title um_template_tags_replaces_hook
-	 * @description Extend UM replace placeholders
-	 * @input_vars
-	 * [{"var":"$replace_placeholders","type":"array","desc":"UM Replace Placeholders"}]
-	 * @change_log
-	 * ["Since: 2.0"]
-	 * @usage add_filter( 'um_template_tags_replaces_hook', 'function_name', 10, 1 );
-	 * @example
-	 * <?php
-	 * add_filter( 'um_template_tags_replaces_hook', 'my_template_tags_replaces', 10, 1 );
-	 * function my_template_tags_replaces( $replace_placeholders ) {
-	 *     // your code here
-	 *     $replace_placeholders[] = 'my_replace_value';
-	 *     return $replace_placeholders;
+	 * Note: Please escape your replacers on this level, otherwise they will be not escaped in the `um_convert_tags()` function, because every replacer can have own escaping.
+	 *
+	 * @param {array} $replace Replacers.
+	 *
+	 * @return {array} Replacers.
+	 *
+	 * @since 1.3.x
+	 * @hook um_template_tags_replaces_hook
+	 *
+	 * @example <caption>Add replace value for placeholder tag with the same numeric key in the $search variable.</caption>
+	 * function custom_um_template_tags_replaces_hook( $replace ) {
+	 *     $replace[] = esc_html( 'something custom' );
+	 *     return $replace;
 	 * }
-	 * ?>
+	 * add_filter( 'um_template_tags_replaces_hook', 'custom_um_template_tags_replaces_hook' );
 	 */
 	$replace = apply_filters( 'um_template_tags_replaces_hook', $replace );
 
 	return array_combine( $search, $replace );
 }
-
 
 /**
  * Convert template tags
@@ -191,17 +180,21 @@ function um_replace_placeholders() {
  * @return mixed|string
  */
 function um_convert_tags( $content, $args = array(), $with_kses = true ) {
-	$placeholders = um_replace_placeholders();
-
-	$content = str_replace( array_keys( $placeholders ), array_values( $placeholders ), $content );
 	if ( $with_kses ) {
+		// Stored template might actually contain: Hi &#123;display_name&#125; instead of Hi {display_name} after WYSIWYG/TinyMCE editor.
+		// So we need to decode HTML entities before we replace placeholders.
+		// We ignore this decoding only in the case when the $content goes from the page content or shortcode.
 		$content = wp_kses_decode_entities( $content );
 	}
 
-	if ( isset( $args['tags'] ) && isset( $args['tags_replace'] ) ) {
-		$content = str_replace( $args['tags'], $args['tags_replace'], $content );
+	$placeholders = um_replace_placeholders();
+	$content      = str_replace( array_keys( $placeholders ), array_values( $placeholders ), $content ); // Important: escapers are already applied in the `um_replace_placeholders()`. Don't need more.
+
+	if ( isset( $args['tags'], $args['tags_replace'] ) ) {
+		$content = str_replace( $args['tags'], $args['tags_replace'], $content );  // Important: escapers have to be already applied in the `tags_replace` argument. Don't need more.
 	}
 
+	// Parsing content for {usermeta:{meta_key}} placeholders.
 	$regex = '~\{(usermeta:[^}]*)\}~';
 	preg_match_all( $regex, $content, $matches );
 
@@ -239,7 +232,27 @@ function um_convert_tags( $content, $args = array(), $with_kses = true ) {
 			if ( is_array( $value ) ) {
 				$value = implode( ', ', $value );
 			}
-			$content = str_replace( '{' . $match . '}', apply_filters( 'um_convert_tags', $value, $key ), $content );
+			/**
+			 * Filters pre-escaped by default {usermeta:{meta_key}} placeholder value and provides an ability to change the value using another escaper.
+			 *
+			 * @param {string} $value     Usermeta escaped by default value. Using esc_html() escaper by default.
+			 * @param {string} $key       Usermeta key.
+			 * @param {string} $raw_value Usermeta raw value.
+			 *
+			 * @return {string} Usermeta value.
+			 *
+			 * @since 2.1.3
+			 * @hook um_convert_tags
+			 *
+			 * @example <caption>Change escape function for usermeta `custom_key` during `um_convert_tags()` placeholders replace.</caption>
+			 * function custom_um_convert_tags( $value, $key, $raw_value ) {
+			 *     $value = 'custom_key' === $key ? wp_kses_post( $raw_value ) : $value;
+			 *     return $value;
+			 * }
+			 * add_filter( 'um_convert_tags', 'custom_um_convert_tags' );
+			 */
+			$value   = apply_filters( 'um_convert_tags', esc_html( $value ), $key, $value ); // Using esc_html() here to prevent XSS attacks. If you need to use any secure HTML here, please use `wp_kses` with the proper context.
+			$content = str_replace( '{' . $match . '}', $value, $content );
 		}
 	}
 	return $content;

--- a/languages/ultimate-member-en_US.po
+++ b/languages/ultimate-member-en_US.po
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-09-03T13:00:54+00:00\n"
+"POT-Creation-Date: 2026-09-07T10:27:23+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: ultimate-member\n"
@@ -4575,8 +4575,8 @@ msgstr ""
 
 #: includes/admin/core/class-admin-settings.php:1479
 #: includes/admin/core/class-admin-settings.php:1685
-#: includes/core/um-actions-profile.php:843
-#: includes/core/um-actions-profile.php:861
+#: includes/core/um-actions-profile.php:845
+#: includes/core/um-actions-profile.php:863
 msgid "Profile photo"
 msgstr ""
 
@@ -6402,12 +6402,12 @@ msgstr ""
 #: includes/class-config.php:242
 #: includes/core/class-fields.php:3040
 #: includes/core/class-fields.php:3183
-#: includes/core/um-actions-profile.php:925
-#: includes/core/um-actions-profile.php:934
-#: includes/core/um-actions-profile.php:1123
-#: includes/core/um-actions-profile.php:1156
-#: includes/core/um-actions-profile.php:1549
-#: includes/core/um-actions-profile.php:1556
+#: includes/core/um-actions-profile.php:927
+#: includes/core/um-actions-profile.php:936
+#: includes/core/um-actions-profile.php:1125
+#: includes/core/um-actions-profile.php:1158
+#: includes/core/um-actions-profile.php:1551
+#: includes/core/um-actions-profile.php:1558
 msgid "Cancel"
 msgstr ""
 
@@ -7025,7 +7025,7 @@ msgstr ""
 #: includes/class-config.php:960
 #: includes/class-config.php:1024
 #: includes/core/class-member-directory.php:2681
-#: includes/core/um-actions-profile.php:1555
+#: includes/core/um-actions-profile.php:1557
 #: includes/core/um-actions-user.php:19
 msgid "Logout"
 msgstr ""
@@ -7732,8 +7732,8 @@ msgid "Cheatin&#8217; huh?"
 msgstr ""
 
 #: includes/common/class-cpt.php:33
-#: includes/um-short-functions.php:716
-#: includes/um-short-functions.php:754
+#: includes/um-short-functions.php:729
+#: includes/um-short-functions.php:767
 msgid "Form"
 msgstr ""
 
@@ -8207,7 +8207,7 @@ msgid "Cover Photo"
 msgstr ""
 
 #: includes/core/class-builtin.php:1295
-#: includes/core/um-actions-profile.php:1003
+#: includes/core/um-actions-profile.php:1005
 msgid "Change your cover photo"
 msgstr ""
 
@@ -9919,8 +9919,8 @@ msgstr ""
 
 #: includes/core/class-fields.php:2977
 #: includes/core/class-fields.php:3039
-#: includes/core/um-actions-profile.php:1121
-#: includes/core/um-actions-profile.php:1154
+#: includes/core/um-actions-profile.php:1123
+#: includes/core/um-actions-profile.php:1156
 msgid "Change photo"
 msgstr ""
 
@@ -10134,7 +10134,7 @@ msgid "Please agree privacy policy."
 msgstr ""
 
 #: includes/core/class-gdpr.php:90
-#: includes/um-short-functions.php:719
+#: includes/um-short-functions.php:732
 msgid "GDPR Applied"
 msgstr ""
 
@@ -10281,13 +10281,13 @@ msgstr ""
 
 #: includes/core/class-member-directory.php:2642
 #: includes/core/class-member-directory.php:2670
-#: includes/core/um-actions-profile.php:1522
-#: includes/core/um-actions-profile.php:1553
+#: includes/core/um-actions-profile.php:1524
+#: includes/core/um-actions-profile.php:1555
 msgid "Edit Profile"
 msgstr ""
 
 #: includes/core/class-member-directory.php:2676
-#: includes/core/um-actions-profile.php:1554
+#: includes/core/um-actions-profile.php:1556
 msgid "My Account"
 msgstr ""
 
@@ -10937,39 +10937,39 @@ msgstr ""
 msgid "Your choosed %s"
 msgstr ""
 
-#: includes/core/um-actions-profile.php:919
-#: includes/core/um-actions-profile.php:920
-#: includes/core/um-actions-profile.php:933
-#: includes/core/um-actions-profile.php:993
+#: includes/core/um-actions-profile.php:921
+#: includes/core/um-actions-profile.php:922
+#: includes/core/um-actions-profile.php:935
+#: includes/core/um-actions-profile.php:995
 #: assets/js/um-profile.js:73
 msgid "Upload a cover photo"
 msgstr ""
 
-#: includes/core/um-actions-profile.php:919
-#: includes/core/um-actions-profile.php:920
+#: includes/core/um-actions-profile.php:921
+#: includes/core/um-actions-profile.php:922
 msgid "Change cover photo"
 msgstr ""
 
-#: includes/core/um-actions-profile.php:924
+#: includes/core/um-actions-profile.php:926
 msgid "Remove cover photo"
 msgstr ""
 
-#: includes/core/um-actions-profile.php:1121
-#: includes/core/um-actions-profile.php:1154
+#: includes/core/um-actions-profile.php:1123
+#: includes/core/um-actions-profile.php:1156
 msgid "Upload photo"
 msgstr ""
 
-#: includes/core/um-actions-profile.php:1122
-#: includes/core/um-actions-profile.php:1155
+#: includes/core/um-actions-profile.php:1124
+#: includes/core/um-actions-profile.php:1157
 msgid "Remove photo"
 msgstr ""
 
-#: includes/core/um-actions-profile.php:1356
+#: includes/core/um-actions-profile.php:1358
 msgid "Tell us a bit about yourself..."
 msgstr ""
 
 #. translators: %s: profile status.
-#: includes/core/um-actions-profile.php:1376
+#: includes/core/um-actions-profile.php:1378
 #, php-format
 msgid "This user account status is %s"
 msgstr ""
@@ -11002,8 +11002,8 @@ msgstr ""
 msgid "This link leads to a 3rd-party website. Make sure the link is safe and you really want to go to this website: '%s'"
 msgstr ""
 
-#: includes/core/um-filters-profile.php:135
-#: includes/core/um-filters-profile.php:156
+#: includes/core/um-filters-profile.php:133
+#: includes/core/um-filters-profile.php:153
 msgid "max"
 msgstr ""
 
@@ -11088,17 +11088,17 @@ msgid "date submitted"
 msgstr ""
 
 #: includes/um-deprecated-functions.php:678
-#: includes/um-short-functions.php:904
-#: includes/um-short-functions.php:965
+#: includes/um-short-functions.php:917
+#: includes/um-short-functions.php:978
 msgid "(empty)"
 msgstr ""
 
-#: includes/um-short-functions.php:714
+#: includes/um-short-functions.php:727
 msgid "User registered date"
 msgstr ""
 
 #. translators: %1$s is a form title; %2$s is a form ID.
-#: includes/um-short-functions.php:887
+#: includes/um-short-functions.php:900
 #, php-format
 msgid "%1$s - Form ID#: %2$s"
 msgstr ""

--- a/languages/ultimate-member.pot
+++ b/languages/ultimate-member.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-09-03T13:00:52+00:00\n"
+"POT-Creation-Date: 2026-09-07T10:27:21+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: ultimate-member\n"
@@ -4575,8 +4575,8 @@ msgstr ""
 
 #: includes/admin/core/class-admin-settings.php:1479
 #: includes/admin/core/class-admin-settings.php:1685
-#: includes/core/um-actions-profile.php:843
-#: includes/core/um-actions-profile.php:861
+#: includes/core/um-actions-profile.php:845
+#: includes/core/um-actions-profile.php:863
 msgid "Profile photo"
 msgstr ""
 
@@ -6402,12 +6402,12 @@ msgstr ""
 #: includes/class-config.php:242
 #: includes/core/class-fields.php:3040
 #: includes/core/class-fields.php:3183
-#: includes/core/um-actions-profile.php:925
-#: includes/core/um-actions-profile.php:934
-#: includes/core/um-actions-profile.php:1123
-#: includes/core/um-actions-profile.php:1156
-#: includes/core/um-actions-profile.php:1549
-#: includes/core/um-actions-profile.php:1556
+#: includes/core/um-actions-profile.php:927
+#: includes/core/um-actions-profile.php:936
+#: includes/core/um-actions-profile.php:1125
+#: includes/core/um-actions-profile.php:1158
+#: includes/core/um-actions-profile.php:1551
+#: includes/core/um-actions-profile.php:1558
 msgid "Cancel"
 msgstr ""
 
@@ -7025,7 +7025,7 @@ msgstr ""
 #: includes/class-config.php:960
 #: includes/class-config.php:1024
 #: includes/core/class-member-directory.php:2681
-#: includes/core/um-actions-profile.php:1555
+#: includes/core/um-actions-profile.php:1557
 #: includes/core/um-actions-user.php:19
 msgid "Logout"
 msgstr ""
@@ -7732,8 +7732,8 @@ msgid "Cheatin&#8217; huh?"
 msgstr ""
 
 #: includes/common/class-cpt.php:33
-#: includes/um-short-functions.php:716
-#: includes/um-short-functions.php:754
+#: includes/um-short-functions.php:729
+#: includes/um-short-functions.php:767
 msgid "Form"
 msgstr ""
 
@@ -8207,7 +8207,7 @@ msgid "Cover Photo"
 msgstr ""
 
 #: includes/core/class-builtin.php:1295
-#: includes/core/um-actions-profile.php:1003
+#: includes/core/um-actions-profile.php:1005
 msgid "Change your cover photo"
 msgstr ""
 
@@ -9919,8 +9919,8 @@ msgstr ""
 
 #: includes/core/class-fields.php:2977
 #: includes/core/class-fields.php:3039
-#: includes/core/um-actions-profile.php:1121
-#: includes/core/um-actions-profile.php:1154
+#: includes/core/um-actions-profile.php:1123
+#: includes/core/um-actions-profile.php:1156
 msgid "Change photo"
 msgstr ""
 
@@ -10134,7 +10134,7 @@ msgid "Please agree privacy policy."
 msgstr ""
 
 #: includes/core/class-gdpr.php:90
-#: includes/um-short-functions.php:719
+#: includes/um-short-functions.php:732
 msgid "GDPR Applied"
 msgstr ""
 
@@ -10281,13 +10281,13 @@ msgstr ""
 
 #: includes/core/class-member-directory.php:2642
 #: includes/core/class-member-directory.php:2670
-#: includes/core/um-actions-profile.php:1522
-#: includes/core/um-actions-profile.php:1553
+#: includes/core/um-actions-profile.php:1524
+#: includes/core/um-actions-profile.php:1555
 msgid "Edit Profile"
 msgstr ""
 
 #: includes/core/class-member-directory.php:2676
-#: includes/core/um-actions-profile.php:1554
+#: includes/core/um-actions-profile.php:1556
 msgid "My Account"
 msgstr ""
 
@@ -10937,39 +10937,39 @@ msgstr ""
 msgid "Your choosed %s"
 msgstr ""
 
-#: includes/core/um-actions-profile.php:919
-#: includes/core/um-actions-profile.php:920
-#: includes/core/um-actions-profile.php:933
-#: includes/core/um-actions-profile.php:993
+#: includes/core/um-actions-profile.php:921
+#: includes/core/um-actions-profile.php:922
+#: includes/core/um-actions-profile.php:935
+#: includes/core/um-actions-profile.php:995
 #: assets/js/um-profile.js:73
 msgid "Upload a cover photo"
 msgstr ""
 
-#: includes/core/um-actions-profile.php:919
-#: includes/core/um-actions-profile.php:920
+#: includes/core/um-actions-profile.php:921
+#: includes/core/um-actions-profile.php:922
 msgid "Change cover photo"
 msgstr ""
 
-#: includes/core/um-actions-profile.php:924
+#: includes/core/um-actions-profile.php:926
 msgid "Remove cover photo"
 msgstr ""
 
-#: includes/core/um-actions-profile.php:1121
-#: includes/core/um-actions-profile.php:1154
+#: includes/core/um-actions-profile.php:1123
+#: includes/core/um-actions-profile.php:1156
 msgid "Upload photo"
 msgstr ""
 
-#: includes/core/um-actions-profile.php:1122
-#: includes/core/um-actions-profile.php:1155
+#: includes/core/um-actions-profile.php:1124
+#: includes/core/um-actions-profile.php:1157
 msgid "Remove photo"
 msgstr ""
 
-#: includes/core/um-actions-profile.php:1356
+#: includes/core/um-actions-profile.php:1358
 msgid "Tell us a bit about yourself..."
 msgstr ""
 
 #. translators: %s: profile status.
-#: includes/core/um-actions-profile.php:1376
+#: includes/core/um-actions-profile.php:1378
 #, php-format
 msgid "This user account status is %s"
 msgstr ""
@@ -11002,8 +11002,8 @@ msgstr ""
 msgid "This link leads to a 3rd-party website. Make sure the link is safe and you really want to go to this website: '%s'"
 msgstr ""
 
-#: includes/core/um-filters-profile.php:135
-#: includes/core/um-filters-profile.php:156
+#: includes/core/um-filters-profile.php:133
+#: includes/core/um-filters-profile.php:153
 msgid "max"
 msgstr ""
 
@@ -11088,17 +11088,17 @@ msgid "date submitted"
 msgstr ""
 
 #: includes/um-deprecated-functions.php:678
-#: includes/um-short-functions.php:904
-#: includes/um-short-functions.php:965
+#: includes/um-short-functions.php:917
+#: includes/um-short-functions.php:978
 msgid "(empty)"
 msgstr ""
 
-#: includes/um-short-functions.php:714
+#: includes/um-short-functions.php:727
 msgid "User registered date"
 msgstr ""
 
 #. translators: %1$s is a form title; %2$s is a form ID.
-#: includes/um-short-functions.php:887
+#: includes/um-short-functions.php:900
 #, php-format
 msgid "%1$s - Form ID#: %2$s"
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -167,12 +167,16 @@ No specific extensions are needed. But we highly recommended keep active these P
 
 IMPORTANT: PLEASE UPDATE THE PLUGIN TO AT LEAST VERSION 2.6.7 IMMEDIATELY. VERSION 2.6.7 PATCHES SECURITY PRIVILEGE ESCALATION VULNERABILITY. PLEASE SEE [THIS ARTICLE](https://docs.ultimatemember.com/article/1866-security-incident-update-and-recommended-actions) FOR MORE INFORMATION
 
-= 2.13.1 2026-08-xx =
+= 2.13.1 2026-09-10 =
 
 **Enhancements**
 
 * Added: Fallback for `wp-cli/wp-config-transformer` library if the wp-config.php file isn't writable.
 * Optimized: Slow SQL query for batch empty account status check.
+
+**Bugfixes**
+
+* Fixed: Security issue related to an unauthenticated visitor can store JavaScript that runs in an administrator's session, through their own profile name. (Reported by Karthik Ramakrishnan and WPScan team). Fixed `um_convert_tags()` function and applied the escapers throughout the placeholder replacement.
 
 = 2.13.0 2026-08-24 =
 
@@ -244,6 +248,9 @@ IMPORTANT: PLEASE UPDATE THE PLUGIN TO AT LEAST VERSION 2.6.7 IMMEDIATELY. VERSI
 [See changelog for all versions](https://plugins.svn.wordpress.org/ultimate-member/trunk/changelog.txt).
 
 == Upgrade Notice ==
+
+= 2.13.1 =
+This version fixes a security related bug. Upgrade immediately.
 
 = 2.13.0 =
 This version fixes a security related bug. Upgrade immediately.


### PR DESCRIPTION
Apply escaping functions to placeholders and tag replacements to address XSS vulnerabilities in user-generated content. Cleanup redundant code comments and improve inline documentation.